### PR TITLE
zsharp fixes ; speed improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__
 /.gdb_history
 .features.txt
 scripts/aby_tests/tests
+/flamegraph*.svg

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 /x
 /perf.data*
 /heaptrack.*
+/flamegraph.*
 /.gdb_history
 .features.txt
 scripts/aby_tests/tests

--- a/scripts/zx_tests/casts_to_field.zx
+++ b/scripts/zx_tests/casts_to_field.zx
@@ -1,0 +1,71 @@
+import "utils/casts/u8_to_field"
+import "utils/casts/u16_to_field"
+import "utils/casts/u32_to_field"
+import "utils/casts/u64_to_field"
+
+def main() -> bool:
+    u8 u8_1 = 170
+    field f8_1 = u8_to_field(u8_1)
+    assert(f8_1 == 170)
+
+    u8 u8_2 = 193
+    field f8_2 = u8_to_field(u8_2)
+    assert(f8_2 == 193)
+
+    u8 u8_3 = 131
+    field f8_3 = u8_to_field(u8_3)
+    assert(f8_3 == 131)
+
+    u8 u8_4 = 85
+    field f8_4 = u8_to_field(u8_4)
+    assert(f8_4 == 85)
+
+    u16 u16_1 = 49470
+    field f16_1 = u16_to_field(u16_1)
+    assert(f16_1 == 49470)
+
+    u16 u16_2 = 33621
+    field f16_2 = u16_to_field(u16_2)
+    assert(f16_2 == 33621)
+
+    u16 u16_3 = 43724
+    field f16_3 = u16_to_field(u16_3)
+    assert(f16_3 == 43724)
+
+    u16 u16_4 = 58601
+    field f16_4 = u16_to_field(u16_4)
+    assert(f16_4 == 58601)
+
+    u32 u32_1 = 2495768655
+    field f32_1 = u32_to_field(u32_1)
+    assert(f32_1 == 2495768655)
+
+    u32 u32_2 = 1964762788
+    field f32_2 = u32_to_field(u32_2)
+    assert(f32_2 == 1964762788)
+
+    u32 u32_3 = 4069444903
+    field f32_3 = u32_to_field(u32_3)
+    assert(f32_3 == 4069444903)
+
+    u32 u32_4 = 23477624
+    field f32_4 = u32_to_field(u32_4)
+    assert(f32_4 == 23477624)
+
+    u64 u64_1 = 4942755304703002651
+    field f64_1 = u64_to_field(u64_1)
+    assert(f64_1 == 4942755304703002651)
+
+    u64 u64_2 = 9575867038914511502
+    field f64_2 = u64_to_field(u64_2)
+    assert(f64_2 == 9575867038914511502)
+
+    u64 u64_3 = 17818881111009702690
+    field f64_3 = u64_to_field(u64_3)
+    assert(f64_3 == 17818881111009702690)
+
+    u64 u64_4 = 10370833667498611482
+    field f64_4 = u64_to_field(u64_4)
+    assert(f64_4 == 10370833667498611482)
+
+    return true

--- a/scripts/zx_tests/casts_to_u16.zx
+++ b/scripts/zx_tests/casts_to_u16.zx
@@ -1,0 +1,20 @@
+import "utils/casts/u8_to_u16"
+
+def main() -> bool:
+    u8 u8_1 = 170
+    u16 f8_1 = u8_to_u16(u8_1)
+    assert(f8_1 == 170)
+
+    u8 u8_2 = 193
+    u16 f8_2 = u8_to_u16(u8_2)
+    assert(f8_2 == 193)
+
+    u8 u8_3 = 131
+    u16 f8_3 = u8_to_u16(u8_3)
+    assert(f8_3 == 131)
+
+    u8 u8_4 = 85
+    u16 f8_4 = u8_to_u16(u8_4)
+    assert(f8_4 == 85)
+
+    return true

--- a/scripts/zx_tests/casts_to_u32.zx
+++ b/scripts/zx_tests/casts_to_u32.zx
@@ -1,0 +1,37 @@
+import "utils/casts/u8_to_u32"
+import "utils/casts/u16_to_u32"
+
+def main() -> bool:
+    u8 u8_1 = 170
+    u32 f8_1 = u8_to_u32(u8_1)
+    assert(f8_1 == 170)
+
+    u8 u8_2 = 193
+    u32 f8_2 = u8_to_u32(u8_2)
+    assert(f8_2 == 193)
+
+    u8 u8_3 = 131
+    u32 f8_3 = u8_to_u32(u8_3)
+    assert(f8_3 == 131)
+
+    u8 u8_4 = 85
+    u32 f8_4 = u8_to_u32(u8_4)
+    assert(f8_4 == 85)
+
+    u16 u16_1 = 49470
+    u32 f16_1 = u16_to_u32(u16_1)
+    assert(f16_1 == 49470)
+
+    u16 u16_2 = 33621
+    u32 f16_2 = u16_to_u32(u16_2)
+    assert(f16_2 == 33621)
+
+    u16 u16_3 = 43724
+    u32 f16_3 = u16_to_u32(u16_3)
+    assert(f16_3 == 43724)
+
+    u16 u16_4 = 58601
+    u32 f16_4 = u16_to_u32(u16_4)
+    assert(f16_4 == 58601)
+
+    return true

--- a/scripts/zx_tests/casts_to_u64.zx
+++ b/scripts/zx_tests/casts_to_u64.zx
@@ -1,0 +1,54 @@
+import "utils/casts/u8_to_u64"
+import "utils/casts/u16_to_u64"
+import "utils/casts/u32_to_u64"
+
+def main() -> bool:
+    u8 u8_1 = 170
+    u64 f8_1 = u8_to_u64(u8_1)
+    assert(f8_1 == 170)
+
+    u8 u8_2 = 193
+    u64 f8_2 = u8_to_u64(u8_2)
+    assert(f8_2 == 193)
+
+    u8 u8_3 = 131
+    u64 f8_3 = u8_to_u64(u8_3)
+    assert(f8_3 == 131)
+
+    u8 u8_4 = 85
+    u64 f8_4 = u8_to_u64(u8_4)
+    assert(f8_4 == 85)
+
+    u16 u16_1 = 49470
+    u64 f16_1 = u16_to_u64(u16_1)
+    assert(f16_1 == 49470)
+
+    u16 u16_2 = 33621
+    u64 f16_2 = u16_to_u64(u16_2)
+    assert(f16_2 == 33621)
+
+    u16 u16_3 = 43724
+    u64 f16_3 = u16_to_u64(u16_3)
+    assert(f16_3 == 43724)
+
+    u16 u16_4 = 58601
+    u64 f16_4 = u16_to_u64(u16_4)
+    assert(f16_4 == 58601)
+
+    u32 u32_1 = 2495768655
+    u64 f32_1 = u32_to_u64(u32_1)
+    assert(f32_1 == 2495768655)
+
+    u32 u32_2 = 1964762788
+    u64 f32_2 = u32_to_u64(u32_2)
+    assert(f32_2 == 1964762788)
+
+    u32 u32_3 = 4069444903
+    u64 f32_3 = u32_to_u64(u32_3)
+    assert(f32_3 == 4069444903)
+
+    u32 u32_4 = 23477624
+    u64 f32_4 = u32_to_u64(u32_4)
+    assert(f32_4 == 23477624)
+
+    return true

--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -157,7 +157,7 @@ impl<'ast> ZGen<'ast> {
     /// Unwrap a result with a span-dependent error
     fn err<E: Display>(&self, e: E, s: &ast::Span) -> ! {
         println!("Error: {}", e);
-        println!("In: {}", self.cur_path().display());
+        println!("In: {}", self.cur_path().canonicalize().unwrap().display());
         s.lines().for_each(|l| print!("  {}", l));
         std::process::exit(1)
     }

--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -820,9 +820,13 @@ impl<'ast> ZGen<'ast> {
             .or_else(|| self.const_lookup_(&i.value).cloned())
         {
             Some(v) => Ok(v),
-            None if IS_CNST => self
-                .cvar_lookup(&i.value)
-                .ok_or_else(|| format!("Undefined const identifier {}", &i.value)),
+            None if IS_CNST => self.cvar_lookup(&i.value).ok_or_else(|| {
+                format!(
+                    "Undefined const identifier {} in {}",
+                    &i.value,
+                    self.cur_path().canonicalize().unwrap().to_string_lossy()
+                )
+            }),
             _ => match self
                 .circ_get_value(Loc::local(i.value.clone()))
                 .map_err(|e| format!("{}", e))?

--- a/src/front/zsharp/term.rs
+++ b/src/front/zsharp/term.rs
@@ -772,7 +772,7 @@ pub fn array_store(array: T, idx: T, val: T) -> Result<T, String> {
 }
 
 fn ir_array<I: IntoIterator<Item = Term>>(sort: Sort, elems: I) -> Term {
-    let mut values = BTreeMap::new();
+    let mut values = HashMap::new();
     let to_insert = elems
         .into_iter()
         .enumerate()
@@ -791,7 +791,7 @@ fn ir_array<I: IntoIterator<Item = Term>>(sort: Sort, elems: I) -> Term {
     let arr = leaf_term(Op::Const(Value::Array(Array::new(
         Sort::Field(DFL_T.clone()),
         Box::new(sort.default_value()),
-        values,
+        values.into_iter().collect::<BTreeMap<_, _>>(),
         len,
     ))));
     to_insert

--- a/src/front/zsharp/term.rs
+++ b/src/front/zsharp/term.rs
@@ -2,7 +2,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Display, Formatter};
 
-use log::warn;
 use rug::Integer;
 
 use crate::circify::{CirCtx, Embeddable};
@@ -742,7 +741,6 @@ pub fn array_select(array: T, idx: T) -> Result<T, String> {
     match array.ty {
         Ty::Array(_, elem_ty) if matches!(idx.ty, Ty::Uint(_) | Ty::Field) => {
             let iterm = if matches!(idx.ty, Ty::Uint(_)) {
-                warn!("warning: indexing array with Uint type");
                 term![Op::UbvToPf(DFL_T.clone()); idx.term]
             } else {
                 idx.term
@@ -757,7 +755,6 @@ pub fn array_store(array: T, idx: T, val: T) -> Result<T, String> {
     if matches!(&array.ty, Ty::Array(_, _)) && matches!(&idx.ty, Ty::Uint(_) | Ty::Field) {
         // XXX(q) typecheck here?
         let iterm = if matches!(idx.ty, Ty::Uint(_)) {
-            warn!("warning: indexing array with Uint type");
             term![Op::UbvToPf(DFL_T.clone()); idx.term]
         } else {
             idx.term

--- a/src/front/zsharp/zvisit/zgenericinf.rs
+++ b/src/front/zsharp/zvisit/zgenericinf.rs
@@ -21,6 +21,7 @@ pub(in super::super) struct ZGenericInf<'ast, 'gen, const IS_CNST: bool> {
     zgen: &'gen ZGen<'ast>,
     fdef: &'gen ast::FunctionDefinition<'ast>,
     gens: &'gen [ast::IdentifierExpression<'ast>],
+    path: &'gen Path,
     sfx: String,
     constr: Option<Term>,
 }
@@ -29,7 +30,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
     pub fn new(
         zgen: &'gen ZGen<'ast>,
         fdef: &'gen ast::FunctionDefinition<'ast>,
-        path: &Path,
+        path: &'gen Path,
         name: &str,
     ) -> Self {
         let gens = fdef.generics.as_ref();
@@ -44,6 +45,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
             zgen,
             fdef,
             gens,
+            path,
             sfx,
             constr: None,
         }
@@ -99,14 +101,16 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
             };
         }
 
+        // self.fdef is in the context of self.path
+        self.zgen.file_stack_push(self.path.to_path_buf());
+
         // 1. build up the already-known generics
         for (cgv, id) in egv.iter().zip(self.fdef.generics.iter()) {
             if let Some(v) = match cgv {
                 CGV::Underscore(_) => None,
-                CGV::Value(v) => Some(self.zgen.literal_(v)),
-                CGV::Identifier(i) => Some(self.const_id_(i)),
+                CGV::Value(v) => Some(self.zgen.literal_(v)?),
+                CGV::Identifier(i) => Some(self.const_id_(i)?),
             } {
-                let v = v?;
                 let var = make_varname(&id.value, &self.sfx);
                 let val = match v.ty {
                     Ty::Uint(32) => Ok(v.term),
@@ -140,6 +144,9 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
         // bracketing invariant
         assert!(self.gens == &self.fdef.generics[..]);
         assert!(self.sfx.ends_with(&self.fdef.id.value));
+
+        // back to calling context
+        self.zgen.file_stack_pop();
 
         // 4. run the solver on the term stack, if it's not already cached
         if let Some(res) = self

--- a/src/front/zsharp/zvisit/zstmtwalker/mod.rs
+++ b/src/front/zsharp/zvisit/zstmtwalker/mod.rs
@@ -638,7 +638,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
     }
 
     fn get_struct(&self, id: &str) -> ZResult<&ast::StructDefinition<'ast>> {
-        self.zgen.get_struct(id).ok_or_else(|| {
+        self.zgen.get_struct(id).map(|(m, _)| m).ok_or_else(|| {
             ZVisitorError(format!("ZStatementWalker: undeclared struct type {}", id))
         })
     }

--- a/src/ir/opt/cfold.rs
+++ b/src/ir/opt/cfold.rs
@@ -58,11 +58,11 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<Term>) -> Term {
         let new_t_opt = match &t.op {
             Op::Not => get(0).as_bool_opt().and_then(|c| cbool(!c)),
             Op::Implies => match get(0).as_bool_opt() {
-                Some(true) => Some(get(1).clone()),
+                Some(true) => Some(get(1)),
                 Some(false) => cbool(true),
                 None => match get(1).as_bool_opt() {
                     Some(true) => cbool(true),
-                    Some(false) => Some(term![NOT; get(0).clone()]),
+                    Some(false) => Some(term![NOT; get(0)]),
                     None => None,
                 },
             },
@@ -100,25 +100,25 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<Term>) -> Term {
                 use BvBinOp::*;
                 match (o, c0.as_bv_opt(), c1.as_bv_opt()) {
                     (Sub, Some(a), Some(b)) => cbv(a.clone() - b.clone()),
-                    (Sub, _, Some(b)) if b.uint() == &Integer::from(0) => Some(c0.clone()),
+                    (Sub, _, Some(b)) if b.uint() == &Integer::from(0) => Some(c0),
                     (Udiv, _, Some(b)) if b.uint() == &Integer::from(0) => Some(bv_lit(
                         (Integer::from(1) << b.width() as u32) - 1,
                         b.width(),
                     )),
                     (Udiv, Some(a), Some(b)) => cbv(a.clone() / b),
-                    (Udiv, _, Some(b)) if b.uint() == &Integer::from(1) => Some(c0.clone()),
+                    (Udiv, _, Some(b)) if b.uint() == &Integer::from(1) => Some(c0),
                     (Udiv, _, Some(b)) if b.uint() == &Integer::from(-1) => {
-                        Some(term![Op::BvUnOp(BvUnOp::Neg); c0.clone()])
+                        Some(term![Op::BvUnOp(BvUnOp::Neg); c0])
                     }
                     // TODO: Udiv by power of two?
                     (Urem, Some(a), Some(b)) => cbv(a.clone() % b),
                     // TODO: Urem by power of two?
-                    (Shl, Some(a), Some(b)) => cbv(a.clone() << b.clone()),
+                    (Shl, Some(a), Some(b)) => cbv(a.clone() << b),
                     (Shl, _, Some(b)) => {
                         assert!(b.uint() < &Integer::from(b.width()));
                         let n = b.uint().to_usize().unwrap();
                         Some(term![BV_CONCAT;
-                          term![Op::BvExtract(b.width()-n-1, 0); c0.clone()],
+                          term![Op::BvExtract(b.width()-n-1, 0); c0],
                           leaf_term(Op::Const(Value::BitVector(BitVector::zeros(n))))
                         ])
                     }
@@ -127,14 +127,14 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<Term>) -> Term {
                         assert!(b.uint() < &Integer::from(b.width()));
                         let n = b.uint().to_usize().unwrap();
                         Some(term![Op::BvSext(n);
-                                   term![Op::BvExtract(b.width()-1, n); c0.clone()]])
+                                   term![Op::BvExtract(b.width()-1, n); c0]])
                     }
                     (Lshr, Some(a), Some(b)) => cbv(a.clone().lshr(b)),
                     (Lshr, _, Some(b)) => {
                         assert!(b.uint() < &Integer::from(b.width()));
                         let n = b.uint().to_usize().unwrap();
                         Some(term![Op::BvUext(n);
-                                   term![Op::BvExtract(b.width()-1, n); c0.clone()]])
+                                   term![Op::BvExtract(b.width()-1, n); c0]])
                     }
                     _ => None,
                 }
@@ -167,22 +167,14 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<Term>) -> Term {
                 let t = get(1);
                 let f = get(2);
                 match c.as_bool_opt() {
-                    Some(true) => Some(t.clone()),
-                    Some(false) => Some(f.clone()),
+                    Some(true) => Some(t),
+                    Some(false) => Some(f),
                     None => match t.as_bool_opt() {
-                        Some(true) => Some(fold_cache(&term![OR; c.clone(), f.clone()], cache)),
-                        Some(false) => Some(fold_cache(
-                            &term![AND; neg_bool(c.clone()), f.clone()],
-                            cache,
-                        )),
+                        Some(true) => Some(fold_cache(&term![OR; c, f], cache)),
+                        Some(false) => Some(fold_cache(&term![AND; neg_bool(c), f], cache)),
                         _ => match f.as_bool_opt() {
-                            Some(true) => Some(fold_cache(
-                                &term![OR; neg_bool(c.clone()), t.clone()],
-                                cache,
-                            )),
-                            Some(false) => {
-                                Some(fold_cache(&term![AND; c.clone(), t.clone()], cache))
-                            }
+                            Some(true) => Some(fold_cache(&term![OR; neg_bool(c), t], cache)),
+                            Some(false) => Some(fold_cache(&term![AND; c, t], cache)),
                             _ => None,
                         },
                     },

--- a/src/ir/opt/cfold.rs
+++ b/src/ir/opt/cfold.rs
@@ -238,6 +238,12 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<Term>) -> Term {
                     1,
                 ))))
             }),
+            Op::BvUext(w) => get(0).as_bv_opt().map(|b| {
+                leaf_term(Op::Const(Value::BitVector(BitVector::new(
+                    b.uint().clone(),
+                    b.width() + w,
+                ))))
+            }),
             _ => None,
         };
         let new_t = {

--- a/src/target/r1cs/trans.rs
+++ b/src/target/r1cs/trans.rs
@@ -89,6 +89,7 @@ impl ToR1cs {
     }
 
     /// Return a bit indicating whether wire `x` is non-zero.
+    #[allow(clippy::wrong_self_convention)]
     fn is_zero(&mut self, x: Lc) -> Lc {
         // m * x - 1 + is_zero == 0
         // is_zero * x == 0

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/EMBED.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/EMBED.zok
@@ -45,3 +45,33 @@ def unpack<N>(field i) -> bool[N]:
 
 def bit_array_le<N>(bool[N] a, bool[N] b) -> bool:
     return false
+
+def u8_to_field(u8 i) -> field:
+    return 0f
+
+def u16_to_field(u16 i) -> field:
+    return 0f
+
+def u32_to_field(u32 i) -> field:
+    return 0f
+
+def u64_to_field(u64 i) -> field:
+    return 0f
+
+def u8_to_u64(u8 i) -> u64:
+    return 0u64
+
+def u16_to_u64(u16 i) -> u64:
+    return 0u64
+
+def u32_to_u64(u32 i) -> u64:
+    return 0u64
+
+def u8_to_u32(u8 i) -> u32:
+    return 0u32
+
+def u16_to_u32(u16 i) -> u32:
+    return 0u32
+
+def u8_to_u16(u8 i) -> u16:
+    return 0u16

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u16_from_bits.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u16_from_bits.zok
@@ -1,4 +1,1 @@
-from "EMBED" import u16_from_bits
-
-def main(bool[16] a) -> u16:
-    return u16_from_bits(a)
+from "EMBED" import u16_from_bits as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u16_to_field.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u16_to_field.zok
@@ -1,10 +1,1 @@
-from "EMBED" import u16_to_bits
-
-def main(u16 i) -> field:
-    bool[16] bits = u16_to_bits(i)
-    field res = 0
-    for u32 j in 0..16 do
-        u32 exponent = 16 - j - 1
-        res = res + if bits[j] then 2 ** exponent else 0 fi
-    endfor
-    return res
+from "EMBED" import u16_to_field as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u16_to_u32.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u16_to_u32.zok
@@ -1,0 +1,1 @@
+from "EMBED" import u16_to_u32 as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u16_to_u64.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u16_to_u64.zok
@@ -1,0 +1,1 @@
+from "EMBED" import u16_to_u64 as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u32_from_bits.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u32_from_bits.zok
@@ -1,4 +1,1 @@
-from "EMBED" import u32_from_bits
-
-def main(bool[32] a) -> u32:
-    return u32_from_bits(a)
+from "EMBED" import u32_from_bits as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u32_to_field.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u32_to_field.zok
@@ -1,10 +1,1 @@
-from "EMBED" import u32_to_bits
-
-def main(u32 i) -> field:
-    bool[32] bits = u32_to_bits(i)
-    field res = 0
-    for u32 j in 0..32 do
-        u32 exponent = 32 - j - 1
-        res = res + if bits[j] then 2 ** exponent else 0 fi
-    endfor
-    return res
+from "EMBED" import u32_to_field as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u32_to_u64.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u32_to_u64.zok
@@ -1,0 +1,1 @@
+from "EMBED" import u32_to_u64 as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u64_from_bits.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u64_from_bits.zok
@@ -1,4 +1,1 @@
-from "EMBED" import u64_from_bits
-
-def main(bool[64] a) -> u64:
-    return u64_from_bits(a)
+from "EMBED" import u64_from_bits as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u64_to_field.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u64_to_field.zok
@@ -1,10 +1,1 @@
-from "EMBED" import u64_to_bits
-
-def main(u64 i) -> field:
-    bool[64] bits = u64_to_bits(i)
-    field res = 0
-    for u32 j in 0..64 do
-        u32 exponent = 64 - j - 1
-        res = res + if bits[j] then 2 ** exponent else 0 fi
-    endfor
-    return res
+from "EMBED" import u64_to_field as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_from_bits.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_from_bits.zok
@@ -1,4 +1,1 @@
-from "EMBED" import u8_from_bits
-
-def main(bool[8] a) -> u8:
-    return u8_from_bits(a)
+from "EMBED" import u8_from_bits as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_to_bits.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_to_bits.zok
@@ -1,4 +1,1 @@
-from "EMBED" import u8_to_bits
-
-def main(u8 a) -> bool[8]:
-    return u8_to_bits(a)
+from "EMBED" import u8_to_bits as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_to_field.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_to_field.zok
@@ -1,10 +1,1 @@
-from "EMBED" import u8_to_bits
-
-def main(u8 i) -> field:
-    bool[8] bits = u8_to_bits(i)
-    field res = 0
-    for u32 j in 0..8 do
-        u32 exponent = 8 - j - 1
-        res = res + if bits[j] then 2 ** exponent else 0 fi
-    endfor
-    return res
+from "EMBED" import u8_to_field as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_to_u16.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_to_u16.zok
@@ -1,0 +1,1 @@
+from "EMBED" import u8_to_u16 as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_to_u32.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_to_u32.zok
@@ -1,0 +1,1 @@
+from "EMBED" import u8_to_u32 as main

--- a/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_to_u64.zok
+++ b/third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/u8_to_u64.zok
@@ -1,0 +1,1 @@
+from "EMBED" import u8_to_u64 as main


### PR DESCRIPTION
This PR does two things:

- Fixes some scoping issues in Z# having to do with the context in which function and struct definitions are interpreted.
- Improves speed and reduces TermTable memory consumption by 2x (by keying on Arc<TermData> rather than TermData)
- Improves speed for Z# array handling with a BTreeMap -> HashMap swap
- Adds intrinsic widening casts in Z#. These were previously handled by bit-splitting, which is wasteful.
 
On array-heavy Z# programs, this PR improves speed by about 5x and memory consumption by roughly the same.

(EDIT: mentioned one other thing this PR does)