### PR TITLE
Improve non-recursive type-checking

### DIFF
--- a/examples/C/mpc/benchmarks/2pc_biomatch_40x.c
+++ b/examples/C/mpc/benchmarks/2pc_biomatch_40x.c
@@ -1,0 +1,38 @@
+int main(
+    __attribute__((private(0))) int db[40960],
+    __attribute__((private(1))) int sample[4])
+{
+    int N = 10240;
+    int K = 4;
+    int matches[N];
+
+    // Compute distances
+    for (int i = 0; i < N; i++)
+    {
+        int db_inner[K];
+        for (int j = 0; j < K; j++)
+        {
+            db_inner[j] = db[i * K + j];
+        }
+
+        int r = 0;
+        for (int k = 0; k < K; k++)
+        {
+            int t = (db_inner[k] - sample[k]);
+            r += t * t;
+        }
+        matches[i] = r;
+    }
+
+    // Compute minimum
+    int best_match = matches[0];
+    for (int l = 1; l < N; l++)
+    {
+        if (matches[l] < best_match)
+        {
+            best_match = matches[l];
+        }
+    }
+
+    return best_match;
+}

--- a/src/ir/term/ty.rs
+++ b/src/ir/term/ty.rs
@@ -90,10 +90,10 @@ fn check_raw_step(t: &Term, tys: &TypeTable) -> Result<Sort, TypeErrorReason> {
                 .map(Sort::BitVector)
         }
         Op::BvUext(a) => {
-            bv_or(&get_ty(&t.cs[0]), "bv-uext").map(|bv| Sort::BitVector(bv.as_bv() + a))
+            bv_or(get_ty(&t.cs[0]), "bv-uext").map(|bv| Sort::BitVector(bv.as_bv() + a))
         }
         Op::BvSext(a) => {
-            bv_or(&get_ty(&t.cs[0]), "bv-uext").map(|bv| Sort::BitVector(bv.as_bv() + a))
+            bv_or(get_ty(&t.cs[0]), "bv-uext").map(|bv| Sort::BitVector(bv.as_bv() + a))
         }
         Op::PfToBv(a) => Ok(Sort::BitVector(*a)),
         Op::Implies => Ok(Sort::Bool),
@@ -105,7 +105,7 @@ fn check_raw_step(t: &Term, tys: &TypeTable) -> Result<Sort, TypeErrorReason> {
         Op::FpBinPred(_) => Ok(Sort::Bool),
         Op::FpUnPred(_) => Ok(Sort::Bool),
         Op::FpUnOp(_) => Ok(get_ty(&t.cs[0]).clone()),
-        Op::BvToFp => match bv_or(&get_ty(&t.cs[0]), "bv-to-fp") {
+        Op::BvToFp => match bv_or(get_ty(&t.cs[0]), "bv-to-fp") {
             Ok(Sort::BitVector(32)) => Ok(Sort::F32),
             Ok(Sort::BitVector(64)) => Ok(Sort::F64),
             Ok(s) => Err(TypeErrorReason::Custom(format!(
@@ -123,7 +123,7 @@ fn check_raw_step(t: &Term, tys: &TypeTable) -> Result<Sort, TypeErrorReason> {
         Op::PfUnOp(_) => Ok(get_ty(&t.cs[0]).clone()),
         Op::PfNaryOp(_) => Ok(get_ty(&t.cs[0]).clone()),
         Op::UbvToPf(m) => Ok(Sort::Field(m.clone())),
-        Op::Select => array_or(&get_ty(&t.cs[0]), "select").map(|(_, v)| v.clone()),
+        Op::Select => array_or(get_ty(&t.cs[0]), "select").map(|(_, v)| v.clone()),
         Op::Store => Ok(get_ty(&t.cs[0]).clone()),
         Op::Tuple => Ok(Sort::Tuple(t.cs.iter().map(get_ty).cloned().collect())),
         Op::Field(i) => {
@@ -147,7 +147,7 @@ fn check_raw_step(t: &Term, tys: &TypeTable) -> Result<Sort, TypeErrorReason> {
             let mut size = 0;
             let mut error = None;
 
-            match arrmap_or(&get_ty(&t.cs[0]), "map") {
+            match arrmap_or(get_ty(&t.cs[0]), "map") {
                 Ok((k, _, s)) => {
                     key_sort = k.clone();
                     size = *s;
@@ -158,7 +158,7 @@ fn check_raw_step(t: &Term, tys: &TypeTable) -> Result<Sort, TypeErrorReason> {
             }
 
             for i in 0..arg_cnt {
-                match array_or(&get_ty(&t.cs[i]), "map inputs") {
+                match array_or(get_ty(&t.cs[i]), "map inputs") {
                     Ok((_, v)) => {
                         dterm_cs.push(v.default_term());
                     }

--- a/src/ir/term/ty.rs
+++ b/src/ir/term/ty.rs
@@ -24,63 +24,81 @@ pub fn check_rec(t: &Term) -> Sort {
     rec_check_raw(t).unwrap()
 }
 
-/// Type-check this term, *non-recursively*.
-/// All results are stored in the global type table.
-pub fn check_raw(t: &Term) -> Result<Sort, TypeError> {
-    if let Some(s) = TERM_TYPES.read().unwrap().get(&t.to_weak()) {
-        return Ok(s.clone());
+/// Return a list of child terms that must be typed first to type this term.
+fn check_dependencies(t: &Term) -> Vec<Term> {
+    match &t.op {
+        Op::Ite => vec![t.cs[1].clone()],
+        Op::Eq => Vec::new(),
+        Op::Var(_, _) => Vec::new(),
+        Op::Const(_) => Vec::new(),
+        Op::BvBinOp(_) => vec![t.cs[0].clone()],
+        Op::BvBinPred(_) => Vec::new(),
+        Op::BvNaryOp(_) => vec![t.cs[0].clone()],
+        Op::BvUnOp(_) => vec![t.cs[0].clone()],
+        Op::BoolToBv => Vec::new(),
+        Op::BvExtract(_, _) => Vec::new(),
+        Op::BvConcat => t.cs.clone(),
+        Op::BvUext(_) => vec![t.cs[0].clone()],
+        Op::BvSext(_) => vec![t.cs[0].clone()],
+        Op::PfToBv(_) => Vec::new(),
+        Op::Implies => Vec::new(),
+        Op::BoolNaryOp(_) => Vec::new(),
+        Op::Not => Vec::new(),
+        Op::BvBit(_) => Vec::new(),
+        Op::BoolMaj => Vec::new(),
+        Op::FpBinOp(_) => vec![t.cs[0].clone()],
+        Op::FpBinPred(_) => Vec::new(),
+        Op::FpUnPred(_) => Vec::new(),
+        Op::FpUnOp(_) => vec![t.cs[0].clone()],
+        Op::BvToFp => vec![t.cs[0].clone()],
+        Op::UbvToFp(_) => Vec::new(),
+        Op::SbvToFp(_) => Vec::new(),
+        Op::FpToFp(_) => Vec::new(),
+        Op::PfUnOp(_) => vec![t.cs[0].clone()],
+        Op::PfNaryOp(_) => vec![t.cs[0].clone()],
+        Op::UbvToPf(_) => Vec::new(),
+        Op::Select => vec![t.cs[0].clone()],
+        Op::Store => vec![t.cs[0].clone()],
+        Op::Tuple => t.cs.clone(),
+        Op::Field(_) => vec![t.cs[0].clone()],
+        Op::Update(_i) => vec![t.cs[0].clone()],
+        Op::Map(_) => t.cs.clone(),
     }
-    // RSW: the below loop is a band-aid to keep from blowing the stack
-    // XXX(q) is there a better way to write this function?
-    let mut t = t;
-    loop {
-        let t_new = match &t.op {
-            Op::Ite => &t.cs[1],
-            Op::BvBinOp(_) => &t.cs[0],
-            Op::BvNaryOp(_) => &t.cs[0],
-            Op::BvUnOp(_) => &t.cs[0],
-            Op::FpBinOp(_) => &t.cs[0],
-            Op::FpUnOp(_) => &t.cs[0],
-            Op::PfUnOp(_) => &t.cs[0],
-            Op::PfNaryOp(_) => &t.cs[0],
-            Op::Store => &t.cs[0],
-            Op::Update(_i) => &t.cs[0],
-            _ => break,
-        };
-        if std::ptr::eq(t, t_new) {
-            panic!("infinite loop detected in check_raw");
-        }
-        t = t_new;
-    }
-    let ty = match &t.op {
-        Op::Ite => Ok(check_raw(&t.cs[1])?),
+}
+
+fn check_raw_step(t: &Term, tys: &TypeTable) -> Result<Sort, TypeErrorReason> {
+    let get_ty = |term: &Term| -> &Sort {
+        tys.get(&term.to_weak()).unwrap_or_else(|| panic!("When checking the type of {} we needed the type of {}, but it was missing. This is a bug in check_dependencies", t, term))
+    };
+    match &t.op {
+        Op::Ite => Ok(get_ty(&t.cs[1]).clone()),
         Op::Eq => Ok(Sort::Bool),
         Op::Var(_, s) => Ok(s.clone()),
         Op::Const(c) => Ok(c.sort()),
-        Op::BvBinOp(_) => Ok(check_raw(&t.cs[0])?),
+        Op::BvBinOp(_) => Ok(get_ty(&t.cs[0]).clone()),
         Op::BvBinPred(_) => Ok(Sort::Bool),
-        Op::BvNaryOp(_) => Ok(check_raw(&t.cs[0])?),
-        Op::BvUnOp(_) => Ok(check_raw(&t.cs[0])?),
+        Op::BvNaryOp(_) => Ok(get_ty(&t.cs[0]).clone()),
+        Op::BvUnOp(_) => Ok(get_ty(&t.cs[0]).clone()),
         Op::BoolToBv => Ok(Sort::BitVector(1)),
         Op::BvExtract(a, b) => Ok(Sort::BitVector(a - b + 1)),
         Op::BvConcat => t
             .cs
             .iter()
-            .map(check_raw)
+            .map(get_ty)
             .try_fold(
-                Ok(0),
-                |l: Result<usize, TypeErrorReason>,
-                 r: Result<Sort, TypeError>|
-                 -> Result<Result<usize, TypeErrorReason>, TypeError> {
-                    r.map(|rr| l.and_then(|lll| bv_or(&rr, "concat").map(|rrr| lll + rrr.as_bv())))
+                0,
+                |l: usize,
+                 r: &Sort|
+                 -> Result<usize, TypeErrorReason> {
+                    bv_or(r, "concat").map(|rr| l + rr.as_bv())
                 },
-            )?
+            )
             .map(Sort::BitVector),
         Op::BvUext(a) => {
-            bv_or(&check_raw(&t.cs[0])?, "bv-uext").map(|bv| Sort::BitVector(bv.as_bv() + a))
+            bv_or(&get_ty(&t.cs[0]), "bv-uext").map(|bv| Sort::BitVector(bv.as_bv() + a))
         }
         Op::BvSext(a) => {
-            bv_or(&check_raw(&t.cs[0])?, "bv-uext").map(|bv| Sort::BitVector(bv.as_bv() + a))
+            bv_or(&get_ty(&t.cs[0]), "bv-uext").map(|bv| Sort::BitVector(bv.as_bv() + a))
         }
         Op::PfToBv(a) => Ok(Sort::BitVector(*a)),
         Op::Implies => Ok(Sort::Bool),
@@ -88,11 +106,11 @@ pub fn check_raw(t: &Term) -> Result<Sort, TypeError> {
         Op::Not => Ok(Sort::Bool),
         Op::BvBit(_) => Ok(Sort::Bool),
         Op::BoolMaj => Ok(Sort::Bool),
-        Op::FpBinOp(_) => Ok(check_raw(&t.cs[0])?),
+        Op::FpBinOp(_) => Ok(get_ty(&t.cs[0]).clone()),
         Op::FpBinPred(_) => Ok(Sort::Bool),
         Op::FpUnPred(_) => Ok(Sort::Bool),
-        Op::FpUnOp(_) => Ok(check_raw(&t.cs[0])?),
-        Op::BvToFp => match bv_or(&check_raw(&t.cs[0])?, "bv-to-fp") {
+        Op::FpUnOp(_) => Ok(get_ty(&t.cs[0]).clone()),
+        Op::BvToFp => match bv_or(&get_ty(&t.cs[0]), "bv-to-fp") {
             Ok(Sort::BitVector(32)) => Ok(Sort::F32),
             Ok(Sort::BitVector(64)) => Ok(Sort::F64),
             Ok(s) => Err(TypeErrorReason::Custom(format!(
@@ -107,16 +125,14 @@ pub fn check_raw(t: &Term) -> Result<Sort, TypeError> {
         Op::SbvToFp(32) => Ok(Sort::F32),
         Op::FpToFp(64) => Ok(Sort::F64),
         Op::FpToFp(32) => Ok(Sort::F32),
-        Op::PfUnOp(_) => Ok(check_raw(&t.cs[0])?),
-        Op::PfNaryOp(_) => Ok(check_raw(&t.cs[0])?),
+        Op::PfUnOp(_) => Ok(get_ty(&t.cs[0]).clone()),
+        Op::PfNaryOp(_) => Ok(get_ty(&t.cs[0]).clone()),
         Op::UbvToPf(m) => Ok(Sort::Field(m.clone())),
-        Op::Select => array_or(&check_raw(&t.cs[0])?, "select").map(|(_, v)| v.clone()),
-        Op::Store => Ok(check_raw(&t.cs[0])?),
-        Op::Tuple => Ok(Sort::Tuple(
-            t.cs.iter().map(check_raw).collect::<Result<_, _>>()?,
-        )),
+        Op::Select => array_or(&get_ty(&t.cs[0]), "select").map(|(_, v)| v.clone()),
+        Op::Store => Ok(get_ty(&t.cs[0]).clone()),
+        Op::Tuple => Ok(Sort::Tuple(t.cs.iter().map(get_ty).cloned().collect())),
         Op::Field(i) => {
-            let sort = check_raw(&t.cs[0])?;
+            let sort = get_ty(&t.cs[0]);
             let sorts = sort.as_tuple();
             if i < &sorts.len() {
                 Ok(sorts[*i].clone())
@@ -127,7 +143,7 @@ pub fn check_raw(t: &Term) -> Result<Sort, TypeError> {
                 )))
             }
         }
-        Op::Update(_i) => Ok(check_raw(&t.cs[0])?),
+        Op::Update(_i) => Ok(get_ty(&t.cs[0]).clone()),
         Op::Map(op) => {
             let arg_cnt = t.cs.len();
             let mut dterm_cs = Vec::new();
@@ -136,7 +152,7 @@ pub fn check_raw(t: &Term) -> Result<Sort, TypeError> {
             let mut size = 0;
             let mut error = None;
 
-            match arrmap_or(&check_raw(&t.cs[0])?, "map") {
+            match arrmap_or(&get_ty(&t.cs[0]), "map") {
                 Ok((k, _, s)) => {
                     key_sort = k.clone();
                     size = *s;
@@ -147,7 +163,7 @@ pub fn check_raw(t: &Term) -> Result<Sort, TypeError> {
             }
 
             for i in 0..arg_cnt {
-                match array_or(&check_raw(&t.cs[i])?, "map inputs") {
+                match array_or(&get_ty(&t.cs[i]), "map inputs") {
                     Ok((_, v)) => {
                         dterm_cs.push(v.default_term());
                     }
@@ -160,25 +176,62 @@ pub fn check_raw(t: &Term) -> Result<Sort, TypeError> {
                 Some(e) => Err(e),
                 None => {
                     let term_ = term((**op).clone(), dterm_cs);
-                    let res_sort = check_raw(&term_)
-                        .map(|val_sort| Sort::Array(Box::new(key_sort), Box::new(val_sort), size));
-                    match res_sort {
-                        Ok(s) => Ok(s),
-                        _ => Err(TypeErrorReason::Custom("map failed".to_string())),
-                    }
+                    Ok(Sort::Array(
+                        Box::new(key_sort),
+                        Box::new(get_ty(&term_).clone()),
+                        size,
+                    ))
                 }
             }
         }
         o => Err(TypeErrorReason::Custom(format!("other operator: {}", o))),
-    };
-    let mut term_tys = TERM_TYPES.write().unwrap();
-    let ty = ty.map_err(|reason| TypeError {
-        op: t.op.clone(),
-        args: vec![], // not quite right..
-        reason,
-    })?;
-    term_tys.insert(t.to_weak(), ty.clone());
-    Ok(ty)
+    }
+}
+
+/// Type-check this term, *non-recursively*.
+/// All results are stored in the global type table.
+pub fn check_raw(t: &Term) -> Result<Sort, TypeError> {
+    if let Some(s) = TERM_TYPES.read().unwrap().get(&t.to_weak()) {
+        return Ok(s.clone());
+    }
+    {
+        let mut term_tys = TERM_TYPES.write().unwrap();
+        // to_check is a stack of (node, cs checked) pairs.
+        let mut to_check = vec![(t.clone(), false)];
+        while !to_check.is_empty() {
+            let back = to_check.last_mut().unwrap();
+            let weak = back.0.to_weak();
+            // The idea here is to check that
+            if let Some((p, _)) = term_tys.get_key_value(&weak) {
+                if p.to_hconsed().is_some() {
+                    to_check.pop();
+                    continue;
+                } else {
+                    term_tys.remove(&weak);
+                }
+            }
+            if !back.1 {
+                back.1 = true;
+                for c in check_dependencies(&back.0) {
+                    to_check.push((c, false));
+                }
+            } else {
+                let ty =
+                    check_raw_step(&back.0, &*term_tys).map_err(|reason| TypeError {
+                        op: back.0.op.clone(),
+                        args: vec![], // not quite right
+                        reason,
+                    })?;
+                term_tys.insert(back.0.to_weak(), ty);
+            }
+        }
+    }
+    Ok(TERM_TYPES
+        .read()
+        .unwrap()
+        .get(&t.to_weak())
+        .unwrap()
+        .clone())
 }
 
 /// Helper function for rec_check_raw


### PR DESCRIPTION

In *non-recursive* type-checking, perhaps better called *type computing*
we perform a minimal traversal in order to compute the type of a term,
without recursively type-checking it. Informally, we assume it is well
typed, and do the minimal amount of work needed to compute its type.

Two improvements:
1. No longer implemented with recursion.
2. Caches all intermediate results.

Implementation:
* `check_dependencies(Term) -> Vec<Term>`: maps a terms to the immediate
  children of it whose types are needed to compute its type.
* `check_raw_step(Term, TypeTable) -> Sort`: assumes those children have
  their types in the table, and computes this term's type.
* `check_raw`: glues the two above functions together into a suitable
  traversal. Similar to `rec_check_raw`, but the traversal isn't total.

Significance:

Previously, we had a non-recursive implementation for array stores that
*didn't cache intermediate results* which could cause quadratic
type-checking time. Edward sent me a benchmark that was experiencing 
this, resulting in 74.1% of total compilation time being spent type-checking.
Now it's down to 0.4% of total compilation time.

Before:
![flamegraph](https://user-images.githubusercontent.com/5809398/162639562-2515f61e-db15-4f63-99f4-78318ca190ea.svg)

After:
![flamegraph](https://user-images.githubusercontent.com/5809398/162639581-31502ff1-da23-4df8-acbb-8ccc53738fab.svg)
