### PR TITLE
improve memory consumption ; add Z# strict unary op, ternary ?:, and type aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "hashconsing"
 version = "1.3.0"
-source = "git+https://github.com/alex-ozdemir/hashconsing.git?branch=phash#a74c1d01742580a16243b6805b647349abbdfe59"
+source = "git+https://github.com/kwantam/hashconsing.git?branch=phash#921f856b935612fb40d64ba03647c5757a828c65"
 dependencies = [
  "lazy_static",
  "lru",
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
+checksum = "32613e41de4c47ab04970c348ca7ae7382cf116625755af070b008a15516a889"
 dependencies = [
  "hashbrown",
 ]
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,10 +614,11 @@ dependencies = [
 [[package]]
 name = "hashconsing"
 version = "1.3.0"
-source = "git+https://github.com/kwantam/hashconsing.git?branch=phash#921f856b935612fb40d64ba03647c5757a828c65"
+source = "git+https://github.com/alex-ozdemir/hashconsing.git?branch=phash#e275caec0f645cb13db2f21298bbfdbc689d9912"
 dependencies = [
  "lazy_static",
  "lru",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -50,18 +50,18 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "approx"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "072df7202e63b127ab55acfe16ce97013d5b97bf160489336d3f1840fd78e99e"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
@@ -91,21 +91,21 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "az"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6dff4a1892b54d70af377bf7a17064192e822865791d812957f21e3108c325"
+checksum = "f771a5d1f5503f7f4279a30f3643d3421ba149848b89ecaaec0ea2acf04a5ac4"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
@@ -138,7 +138,7 @@ dependencies = [
  "log",
  "num_cpus",
  "pairing",
- "rand_core",
+ "rand_core 0.6.3",
  "rayon",
  "subtle",
 ]
@@ -148,6 +148,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "bitvec"
@@ -202,7 +211,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -220,9 +229,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -246,6 +255,7 @@ dependencies = [
  "good_lp",
  "hashconsing",
  "ieee754",
+ "im",
  "itertools 0.10.3",
  "lang-c",
  "lazy_static",
@@ -287,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -324,9 +334,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -345,10 +355,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -358,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -420,9 +431,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "synstructure",
 ]
 
@@ -433,6 +444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ff"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,7 +461,7 @@ dependencies = [
  "bitvec",
  "byteorder",
  "ff_derive 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -452,9 +472,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e715451ab983be06481e927a275ec12372103ad426c7cb82cebfe14698ed4cf4"
 dependencies = [
  "num-traits",
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -467,9 +487,9 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -481,16 +501,16 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "fnv"
@@ -534,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -545,15 +565,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "gmp-mpfr-sys"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a146a7357ce9573bdcc416fc4a99b960e166e72d8eaffa7c59966d51866b5bfb"
+checksum = "b3d00b0ef965511028498a1668c4a6ef9b0b2501a4a5ab26fb8156408869306e"
 dependencies = [
  "libc",
  "winapi",
@@ -561,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "good_lp"
-version = "1.2.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8fba2696c6b6fce795aa113be95338541a1e08e7a80fc06ceded3e152a9c3f"
+checksum = "b51d78cbb7b734379eea7f811ddb33b2b13defefa1dab50068d7bc7f781a3056"
 dependencies = [
  "coin_cbc",
  "fnv",
@@ -578,7 +598,7 @@ checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "byteorder",
  "ff",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -631,13 +651,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
-name = "indexmap"
-version = "1.7.0"
+name = "im"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.5.1",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -660,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "lang-c"
@@ -678,15 +721,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.104"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
@@ -708,10 +751,10 @@ checksum = "56a7d287fd2ac3f75b11f19a1c8a874a7d55744bd91f7a1b3e7cf87d4343c36d"
 dependencies = [
  "beef",
  "fnv",
- "proc-macro2 1.0.30",
- "quote 1.0.10",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "regex-syntax",
- "syn 1.0.80",
+ "syn 1.0.91",
  "utf8-ranges",
 ]
 
@@ -748,9 +791,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -797,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -807,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
 ]
@@ -837,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pest"
@@ -881,9 +924,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -909,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ca011bd0129ff4ae15cd04c4eef202cadf6c51c21e47aba319b4e0501db741"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-error"
@@ -920,9 +963,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "version_check",
 ]
 
@@ -932,8 +975,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.30",
- "quote 1.0.10",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "version_check",
 ]
 
@@ -948,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -972,9 +1015,9 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
 dependencies = [
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -988,11 +1031,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
- "proc-macro2 1.0.30",
+ "proc-macro2 1.0.37",
 ]
 
 [[package]]
@@ -1003,14 +1046,13 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1020,8 +1062,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -1033,19 +1081,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
+name = "rand_xoshiro"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1055,31 +1103,30 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1112,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "rug"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0c6e98de59509e62e09f3456b23cebb75dad21928882016f169bb628843459"
+checksum = "6ac804305677221f4c82469fd7eb8bfe00dd01420aa191197cb87d738520feef"
 dependencies = [
  "az",
  "gmp-mpfr-sys",
@@ -1129,9 +1176,9 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "scopeguard"
@@ -1141,29 +1188,29 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
@@ -1192,6 +1239,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,9 +1256,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1216,9 +1273,9 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1240,12 +1297,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
- "proc-macro2 1.0.30",
- "quote 1.0.10",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "unicode-xid 0.2.2",
 ]
 
@@ -1255,9 +1312,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "unicode-xid 0.2.2",
 ]
 
@@ -1269,13 +1326,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1283,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -1314,9 +1371,9 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1327,9 +1384,9 @@ checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
@@ -1339,9 +1396,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -1363,9 +1420,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "utf8-ranges"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "vec_map"
@@ -1375,9 +1432,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 circ_fields = { path = "circ_fields" }
 #hashconsing = "1.3"
-hashconsing = { git = "https://github.com/alex-ozdemir/hashconsing.git", branch = "phash"}
+hashconsing = { git = "https://github.com/kwantam/hashconsing.git", branch = "phash"}
 rug = "1.11"
 gmp-mpfr-sys = "1.4"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 circ_fields = { path = "circ_fields" }
 #hashconsing = "1.3"
-hashconsing = { git = "https://github.com/kwantam/hashconsing.git", branch = "phash"}
+hashconsing = { git = "https://github.com/alex-ozdemir/hashconsing.git", branch = "phash"}
 rug = "1.11"
 gmp-mpfr-sys = "1.4"
 lazy_static = "1.4"

--- a/examples/zxc.rs
+++ b/examples/zxc.rs
@@ -59,6 +59,10 @@ struct Options {
 
     #[structopt(long, default_value = "count")]
     action: ProofAction,
+
+    #[structopt(short = "q")]
+    /// quiet mode: don't print R1CS at the end
+    quiet: bool,
 }
 
 #[derive(Debug, StructOpt)]
@@ -152,7 +156,9 @@ fn main() {
     println!("Final R1cs size: {}", r1cs.constraints().len());
     match action {
         ProofAction::Count => {
-            eprintln!("{:#?}", r1cs.constraints());
+            if !options.quiet {
+                eprintln!("{:#?}", r1cs.constraints());
+            }
         }
         ProofAction::Prove => {
             unimplemented!()

--- a/scripts/zx_tests/typedef_1.zx
+++ b/scripts/zx_tests/typedef_1.zx
@@ -1,0 +1,4 @@
+type Foo = u8
+
+def main() -> Foo:
+    return 0

--- a/scripts/zx_tests/typedef_2.zx
+++ b/scripts/zx_tests/typedef_2.zx
@@ -1,0 +1,11 @@
+struct Foo<N, M> {
+    field[N] n
+    field[M] m
+}
+
+type Bar<N> = Foo<N, N>
+
+def main() -> bool:
+    Foo<5, 5> q = Foo { n: [0; 5], m: [0; 5] }
+    Bar<5> u = Bar { n: [0; 5], m: [0; 5] }
+    return q == u

--- a/scripts/zx_tests/typedef_3.zx
+++ b/scripts/zx_tests/typedef_3.zx
@@ -1,0 +1,21 @@
+struct Foo<N> {
+    field[N] n
+}
+
+type Bar = Foo<5>
+
+struct Baz<N> {
+    Bar b
+    Foo<N> q
+}
+
+type Quux = Baz<7>
+
+const u32 SEVEN = 7
+
+type Bazinga = field[SEVEN]
+
+def main() -> bool:
+    Quux q = Quux { b: Bar { n: [0; 5] }, q: Foo { n: [1; 7] } }
+    Baz<5> r = Quux { b: Foo { n: [q.b.n[0]; 5] }, q: Bar { n: [2; 5] } }
+    return r.b.n[4] == q.b.n[4]

--- a/scripts/zx_tests/typedef_4.zx
+++ b/scripts/zx_tests/typedef_4.zx
@@ -1,0 +1,5 @@
+from "./typedef_3" import Bazinga
+
+def main() -> bool:
+    Bazinga foo = [0; 7]
+    return foo[0] == 1

--- a/scripts/zx_tests/typedef_5.zxf
+++ b/scripts/zx_tests/typedef_5.zxf
@@ -1,0 +1,5 @@
+from "./typedef_3" import Bar
+
+def main() -> bool:
+    Bar q = Bar { n: [0; 5] }
+    return q.n[0] == 0

--- a/src/front/zsharp/TODO
+++ b/src/front/zsharp/TODO
@@ -1,14 +1,3 @@
-- casts
-    - widening casts are free!
-    - check narrowing cast correctness!
-    - look at unpack functions again
-    - look at pack: advantage to builtin?
-
-    u8:             | u16 u32 u64 field
-    u16: u8         |     u32 u64 field
-    u32: u8 u16     |         u64 field
-    u64: u8 u16 u32 |             field
-
 - error messages: (String, &Span) instead of String to avoid recursively
   expanding Spans on error?
 
@@ -31,9 +20,6 @@
 
 --
 wants
-
-- improve speed (atomics?)
-  - shake is fast in zxi but slow in zxc (linearity reduction)
 
 --> fix field up-front?
 
@@ -80,3 +66,17 @@ wants
 [x] lints
 
 [x] pretty-printing T
+
+[x] improve speed (atomics?)
+  - shake is fast in zxi but slow in zxc (linearity reduction)
+
+[x] casts
+    - widening casts are free!
+    - check narrowing cast correctness!
+    - look at unpack functions again
+    - look at pack: advantage to builtin?
+
+    u8:             | u16 u32 u64 field
+    u16: u8         |     u32 u64 field
+    u32: u8 u16     |         u64 field
+    u64: u8 u16 u32 |             field

--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -1455,7 +1455,7 @@ impl<'ast> ZGen<'ast> {
                         &s.id.value
                     )
                 })?;
-                let generics = match def.as_ref() {
+                let generics = match def {
                     Ok(sdef) => &sdef.generics,
                     Err(tdef) => &tdef.generics,
                 };
@@ -1770,14 +1770,14 @@ impl<'ast> ZGen<'ast> {
         &self,
         struct_id: &str,
     ) -> Option<(
-        &Result<ast::StructDefinition<'ast>, ast::TypeDefinition<'ast>>,
+        Result<&ast::StructDefinition<'ast>, &ast::TypeDefinition<'ast>>,
         PathBuf,
     )> {
         let (s_path, s_name) = self.deref_import(struct_id);
         self.structs_and_tys
             .get(&s_path)
             .and_then(|m| m.get(&s_name))
-            .map(|m| (m, s_path))
+            .map(|m| (m.as_ref(), s_path))
     }
 
     /*** circify wrapper functions (hides RefCell) ***/

--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -1474,13 +1474,13 @@ impl<'ast> ZGen<'ast> {
                 }
                 self.file_stack_push(path);
                 self.generics_stack_push(generics);
-                let ty = match def.as_ref() {
+                let ty = match def {
                     Ok(sdef) => Ty::new_struct(
                         sdef.id.value.clone(),
                         sdef.fields
-                            .into_iter()
+                            .iter()
                             .map::<Result<_, String>, _>(|f| {
-                                Ok((f.id.value, self.type_impl_::<IS_CNST>(&f.ty)?))
+                                Ok((f.id.value.clone(), self.type_impl_::<IS_CNST>(&f.ty)?))
                             })
                             .collect::<Result<Vec<_>, _>>()?,
                     ),

--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -1030,20 +1030,12 @@ impl<'ast> ZGen<'ast> {
         match self
             .get_struct_or_type(id)
             .ok_or_else(|| format!("No such struct or type {} canonicalizing InlineStruct", id))?
+            .0
         {
-            (Ok(_), _) => Ok(id.to_string()),
-            (Err(t), p) => match &t.ty {
-                ast::Type::Struct(s) => {
-                    self.file_stack_push(p);
-                    let ret = self.canon_struct(&s.id.value);
-                    self.file_stack_pop();
-                    ret
-                }
-                _ => Err(format!(
-                    "Found non-Struct canonicalizing struct {} at {}",
-                    id,
-                    p.to_string_lossy(),
-                )),
+            Ok(_) => Ok(id.to_string()),
+            Err(t) => match &t.ty {
+                ast::Type::Struct(s) => self.canon_struct(&s.id.value),
+                _ => Err(format!("Found non-Struct canonicalizing struct {}", id,)),
             },
         }
     }

--- a/src/front/zsharp/parser.rs
+++ b/src/front/zsharp/parser.rs
@@ -84,12 +84,19 @@ impl ZStdLib {
         let paths = [parent.to_path_buf(), self.path.clone()];
         for mut p in paths {
             p.push(child);
-            if p.extension().is_none() {
-                p.set_extension("zok");
-            }
             debug!("Checking {}", p.display());
             if p.exists() {
                 return p;
+            }
+            if p.extension().is_some() {
+                continue;
+            }
+            for ext in ["zok", "zx"] {
+                p.set_extension(ext);
+                debug!("Checking {}", p.display());
+                if p.exists() {
+                    return p;
+                }
             }
         }
         panic!("Could not find {} from {}", child, parent.display())

--- a/src/front/zsharp/term.rs
+++ b/src/front/zsharp/term.rs
@@ -606,7 +606,7 @@ pub fn const_bool(a: T) -> Option<bool> {
 pub fn const_val(a: T) -> Result<T, String> {
     match const_value(&a.term) {
         Some(v) => Ok(T::new(a.ty, leaf_term(Op::Const(v)))),
-        _ => Err(format!("{} is not a constant basic type", &a)),
+        _ => Err(format!("{} is not a constant value", &a)),
     }
 }
 

--- a/src/front/zsharp/zvisit/eqtype.rs
+++ b/src/front/zsharp/zvisit/eqtype.rs
@@ -1,15 +1,20 @@
 //! AST Walker for zokrates_pest_ast
 
-use super::{ZVisitorError, ZVisitorResult};
+use super::super::ZGen;
+use super::{ZResult, ZVisitorError, ZVisitorResult};
 
 use zokrates_pest_ast as ast;
 
-pub fn eq_type<'ast>(ty: &ast::Type<'ast>, ty2: &ast::Type<'ast>) -> ZVisitorResult {
+pub(super) fn eq_type<'ast>(
+    ty: &ast::Type<'ast>,
+    ty2: &ast::Type<'ast>,
+    zgen: &ZGen<'ast>,
+) -> ZVisitorResult {
     use ast::Type::*;
     match (ty, ty2) {
         (Basic(bty), Basic(bty2)) => eq_basic_type(bty, bty2),
-        (Array(aty), Array(aty2)) => eq_array_type(aty, aty2),
-        (Struct(sty), Struct(sty2)) => eq_struct_type(sty, sty2),
+        (Array(aty), Array(aty2)) => eq_array_type(aty, aty2, zgen),
+        (Struct(sty), Struct(sty2)) => eq_struct_type(sty, sty2, zgen),
         _ => Err(ZVisitorError(format!(
             "type mismatch: expected {:?}, found {:?}",
             ty, ty2,
@@ -17,10 +22,7 @@ pub fn eq_type<'ast>(ty: &ast::Type<'ast>, ty2: &ast::Type<'ast>) -> ZVisitorRes
     }
 }
 
-pub fn eq_basic_type<'ast>(
-    ty: &ast::BasicType<'ast>,
-    ty2: &ast::BasicType<'ast>,
-) -> ZVisitorResult {
+fn eq_basic_type<'ast>(ty: &ast::BasicType<'ast>, ty2: &ast::BasicType<'ast>) -> ZVisitorResult {
     use ast::BasicType::*;
     match (ty, ty2) {
         (Field(_), Field(_)) => Ok(()),
@@ -36,9 +38,10 @@ pub fn eq_basic_type<'ast>(
     }
 }
 
-pub fn eq_array_type<'ast>(
+fn eq_array_type<'ast>(
     ty: &ast::ArrayType<'ast>,
     ty2: &ast::ArrayType<'ast>,
+    zgen: &ZGen<'ast>,
 ) -> ZVisitorResult {
     use ast::BasicOrStructType::*;
     if ty.dimensions.len() != ty2.dimensions.len() {
@@ -50,7 +53,7 @@ pub fn eq_array_type<'ast>(
     }
     match (&ty.ty, &ty2.ty) {
         (Basic(bty), Basic(bty2)) => eq_basic_type(bty, bty2),
-        (Struct(sty), Struct(sty2)) => eq_struct_type(sty, sty2),
+        (Struct(sty), Struct(sty2)) => eq_struct_type(sty, sty2, zgen),
         _ => Err(ZVisitorError(format!(
             "array type mismatch: expected elms of type {:?}, found {:?}",
             &ty.ty, &ty2.ty,
@@ -58,17 +61,44 @@ pub fn eq_array_type<'ast>(
     }
 }
 
-pub fn eq_struct_type<'ast>(
+fn eq_struct_type<'ast>(
     ty: &ast::StructType<'ast>,
     ty2: &ast::StructType<'ast>,
+    zgen: &ZGen<'ast>,
 ) -> ZVisitorResult {
-    if ty.id.value != ty2.id.value {
+    if ty.id.value == ty2.id.value {
+        Ok(())
+    } else if is_struct(&ty.id.value, zgen) && is_struct(&ty2.id.value, zgen) {
+        // neither ty nor ty2 is a type alias, so they are really different
         Err(ZVisitorError(format!(
             "struct type mismatch: expected {:?}, found {:?}",
             &ty.id.value, &ty2.id.value,
         )))
     } else {
-        // don't check generics here; they'll get checked after monomorphization
-        Ok(())
+        eq_type(&canon_type(ty, zgen)?, &canon_type(ty2, zgen)?, zgen)
     }
+}
+
+fn is_struct<'ast>(id: &str, zgen: &ZGen<'ast>) -> bool {
+    zgen.get_struct_or_type(id)
+        .map(|(s, _)| s.is_ok())
+        .unwrap_or(false)
+}
+
+fn canon_type<'ast>(ty: &ast::StructType<'ast>, zgen: &ZGen<'ast>) -> ZResult<ast::Type<'ast>> {
+    zgen.get_struct_or_type(&ty.id.value)
+        .map(|(s, _)| match s {
+            Ok(sd) => ast::Type::Struct(ast::StructType {
+                id: sd.id.clone(),
+                explicit_generics: None,
+                span: sd.span.clone(),
+            }),
+            Err(t) => t.ty.clone(),
+        })
+        .ok_or_else(|| {
+            ZVisitorError(format!(
+                "eqtype: unknown struct or type alias {}",
+                &ty.id.value
+            ))
+        })
 }

--- a/src/front/zsharp/zvisit/walkfns.rs
+++ b/src/front/zsharp/zvisit/walkfns.rs
@@ -60,7 +60,7 @@ pub fn walk_main_import_directive<'ast, Z: ZVisitorMut<'ast>>(
     visitor: &mut Z,
     mimport: &mut ast::MainImportDirective<'ast>,
 ) -> ZVisitorResult {
-    visitor.visit_import_source(&mut mimport.source)?;
+    visitor.visit_any_string(&mut mimport.source)?;
     if let Some(ie) = &mut mimport.alias {
         visitor.visit_identifier_expression(ie)?;
     }
@@ -71,7 +71,7 @@ pub fn walk_from_import_directive<'ast, Z: ZVisitorMut<'ast>>(
     visitor: &mut Z,
     fimport: &mut ast::FromImportDirective<'ast>,
 ) -> ZVisitorResult {
-    visitor.visit_import_source(&mut fimport.source)?;
+    visitor.visit_any_string(&mut fimport.source)?;
     fimport
         .symbols
         .iter_mut()
@@ -79,9 +79,9 @@ pub fn walk_from_import_directive<'ast, Z: ZVisitorMut<'ast>>(
     visitor.visit_span(&mut fimport.span)
 }
 
-pub fn walk_import_source<'ast, Z: ZVisitorMut<'ast>>(
+pub fn walk_any_string<'ast, Z: ZVisitorMut<'ast>>(
     visitor: &mut Z,
-    is: &mut ast::ImportSource<'ast>,
+    is: &mut ast::AnyString<'ast>,
 ) -> ZVisitorResult {
     visitor.visit_span(&mut is.span)
 }
@@ -525,6 +525,7 @@ pub fn walk_unary_operator<'ast, Z: ZVisitorMut<'ast>>(
         Pos(po) => visitor.visit_pos_operator(po),
         Neg(ne) => visitor.visit_neg_operator(ne),
         Not(no) => visitor.visit_not_operator(no),
+        Strict(so) => visitor.visit_strict_operator(so),
     }
 }
 
@@ -765,6 +766,9 @@ pub fn walk_assertion_statement<'ast, Z: ZVisitorMut<'ast>>(
     asrt: &mut ast::AssertionStatement<'ast>,
 ) -> ZVisitorResult {
     visitor.visit_expression(&mut asrt.expression)?;
+    if let Some(s) = &mut asrt.message {
+        visitor.visit_any_string(s)?;
+    }
     visitor.visit_span(&mut asrt.span)
 }
 

--- a/src/front/zsharp/zvisit/walkfns.rs
+++ b/src/front/zsharp/zvisit/walkfns.rs
@@ -41,6 +41,7 @@ pub fn walk_symbol_declaration<'ast, Z: ZVisitorMut<'ast>>(
         Import(i) => visitor.visit_import_directive(i),
         Constant(c) => visitor.visit_constant_definition(c),
         Struct(s) => visitor.visit_struct_definition(s),
+        Type(t) => visitor.visit_type_definition(t),
         Function(f) => visitor.visit_function_definition(f),
     }
 }
@@ -127,6 +128,19 @@ pub fn walk_struct_definition<'ast, Z: ZVisitorMut<'ast>>(
         .fields
         .iter_mut()
         .try_for_each(|f| visitor.visit_struct_field(f))?;
+    visitor.visit_span(&mut structdef.span)
+}
+
+pub fn walk_type_definition<'ast, Z: ZVisitorMut<'ast>>(
+    visitor: &mut Z,
+    structdef: &mut ast::TypeDefinition<'ast>,
+) -> ZVisitorResult {
+    visitor.visit_identifier_expression(&mut structdef.id)?;
+    structdef
+        .generics
+        .iter_mut()
+        .try_for_each(|g| visitor.visit_identifier_expression(g))?;
+    visitor.visit_type(&mut structdef.ty)?;
     visitor.visit_span(&mut structdef.span)
 }
 

--- a/src/front/zsharp/zvisit/zgenericinf.rs
+++ b/src/front/zsharp/zvisit/zgenericinf.rs
@@ -204,7 +204,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
         match def_ty {
             TT::Basic(dty_b) => self.fdef_gen_ty_basic(arg_ty, dty_b),
             TT::Array(dty_a) => self.fdef_gen_ty_array(arg_ty, dty_a),
-            TT::Struct(dty_s) => self.fdef_gen_ty_struct(arg_ty, dty_s),
+            TT::Struct(dty_s) => self.fdef_gen_ty_struct_or_type(arg_ty, dty_s),
         }
     }
 
@@ -275,35 +275,27 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
 
         use ast::BasicOrStructType as BoST;
         match &def_ty.ty {
-            BoST::Struct(dty_s) => self.fdef_gen_ty_struct(arg_ty, dty_s),
+            BoST::Struct(dty_s) => self.fdef_gen_ty_struct_or_type(arg_ty, dty_s),
             BoST::Basic(dty_b) => self.fdef_gen_ty_basic(arg_ty, dty_b),
         }
     }
 
-    fn fdef_gen_ty_struct(
+    fn fdef_gen_ty_struct_or_type(
         &mut self,
         arg_ty: Ty,
         def_ty: &ast::StructType<'ast>,
     ) -> Result<(), String> {
-        // check type and struct name
-        let mut aty_map = match arg_ty {
-            Ty::Struct(aty_n, aty_map) if aty_n == def_ty.id.value => Ok(aty_map.into_map()),
-            Ty::Struct(aty_n, _) => Err(format!(
-                "Type mismatch: got struct {}, decl was struct {}",
-                &aty_n, &def_ty.id.value
-            )),
-            arg_ty => Err(format!(
-                "Type mismatch unifying generics: got {}, decl was Struct",
-                arg_ty
-            )),
-        }?;
-        let (strdef, strpath) = self
+        let (stdef, stpath) = self
             .zgen
-            .get_struct(&def_ty.id.value)
-            .ok_or_else(|| format!("ZGenericInf: no such struct {}", &def_ty.id.value))?;
+            .get_struct_or_type(&def_ty.id.value)
+            .ok_or_else(|| format!("ZGenericInf: no struct struct or type {}", &def_ty.id.value))?;
+        let generics = match &stdef {
+            Ok(strdef) => &strdef.generics[..],
+            Err(tydef) => &tydef.generics[..],
+        };
 
         // short-circuit if there are no generics in this struct
-        if strdef.generics.is_empty() {
+        if generics.is_empty() {
             return if def_ty.explicit_generics.is_some() {
                 Err(format!(
                     "Unifying generics: got explicit generics for non-generic struct type {}:\n{}",
@@ -338,7 +330,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
             .unwrap()
             .values
             .iter()
-            .zip(strdef.generics.iter())
+            .zip(generics.iter())
             .try_for_each::<_, Result<(), String>>(|(cgv, id)| {
                 let sgid = make_varname(&id.value, &new_sfx);
                 let val = match cgv {
@@ -358,28 +350,49 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
 
         // 2. walk through struct def to generate constraints on inner explicit generics
         let old_sfx = std::mem::replace(&mut self.sfx, new_sfx);
-        let old_gens = std::mem::replace(&mut self.gens, &strdef.generics[..]);
-        self.zgen.file_stack_push(strpath);
-        for ast::StructField { ty, id, .. } in strdef.fields.iter() {
-            if let Some(t) = aty_map.remove(&id.value) {
-                self.fdef_gen_ty(t, &ty)?;
-            } else {
-                return Err(format!(
-                    "ZGenericInf: missing member {} in struct {} value",
-                    &id.value, &def_ty.id.value,
-                ));
+        let old_gens = std::mem::replace(&mut self.gens, generics);
+        self.zgen.file_stack_push(stpath);
+        match stdef {
+            Ok(strdef) => {
+                // check type and struct name
+                let mut aty_map = match arg_ty {
+                    Ty::Struct(aty_n, aty_map) if aty_n == def_ty.id.value => {
+                        Ok(aty_map.into_map())
+                    }
+                    Ty::Struct(aty_n, _) => Err(format!(
+                        "Type mismatch: got struct {}, decl was struct {}",
+                        &aty_n, &def_ty.id.value
+                    )),
+                    arg_ty => Err(format!(
+                        "Type mismatch unifying generics: got {}, decl was Struct",
+                        arg_ty
+                    )),
+                }?;
+                for ast::StructField { ty, id, .. } in strdef.fields.iter() {
+                    if let Some(t) = aty_map.remove(&id.value) {
+                        self.fdef_gen_ty(t, ty)?;
+                    } else {
+                        return Err(format!(
+                            "ZGenericInf: missing member {} in struct {} value",
+                            &id.value, &def_ty.id.value,
+                        ));
+                    }
+                }
+                if !aty_map.is_empty() {
+                    return Err(format!(
+                        "ZGenericInf: struct {} value had extra members: {:?}",
+                        &def_ty.id.value,
+                        aty_map.keys().collect::<Vec<_>>(),
+                    ));
+                }
             }
-        }
-        self.zgen.file_stack_pop();
-        if !aty_map.is_empty() {
-            return Err(format!(
-                "ZGenericInf: struct {} value had extra members: {:?}",
-                &def_ty.id.value,
-                aty_map.keys().collect::<Vec<_>>(),
-            ));
+            Err(tydef) => {
+                self.fdef_gen_ty(arg_ty, &tydef.ty)?;
+            }
         }
 
         // 3. pop stack and continue
+        self.zgen.file_stack_pop();
         self.gens = old_gens;
         self.sfx = old_sfx;
         Ok(())

--- a/src/front/zsharp/zvisit/zgenericinf.rs
+++ b/src/front/zsharp/zvisit/zgenericinf.rs
@@ -362,7 +362,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
         self.zgen.file_stack_push(strpath);
         for ast::StructField { ty, id, .. } in strdef.fields.iter() {
             if let Some(t) = aty_map.remove(&id.value) {
-                self.fdef_gen_ty(t, ty)?;
+                self.fdef_gen_ty(t, &ty)?;
             } else {
                 return Err(format!(
                     "ZGenericInf: missing member {} in struct {} value",

--- a/src/front/zsharp/zvisit/zstmtwalker/mod.rs
+++ b/src/front/zsharp/zvisit/zstmtwalker/mod.rs
@@ -1,6 +1,5 @@
 //! AST Walker for zokrates_pest_ast
 
-mod zexprrewriter;
 mod zexprtyper;
 
 use super::super::term::Ty;
@@ -10,7 +9,6 @@ use super::walkfns::*;
 use super::{
     bos_to_type, ZConstLiteralRewriter, ZResult, ZVisitorError, ZVisitorMut, ZVisitorResult,
 };
-use zexprrewriter::ZExpressionRewriter;
 use zexprtyper::ZExpressionTyper;
 
 use std::collections::HashMap;
@@ -42,13 +40,17 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         }
     }
 
+    fn eq_type(&self, ty: &ast::Type<'ast>, ty2: &ast::Type<'ast>) -> ZVisitorResult {
+        eq_type(ty, ty2, self.zgen)
+    }
+
     fn type_expression<'wlk>(
         &self,
         expr: &mut ast::Expression<'ast>,
         zty: &mut ZExpressionTyper<'ast, 'ret, 'wlk>,
     ) -> ZResult<Option<ast::Type<'ast>>> {
         zty.visit_expression(expr)?;
-        zty.take()
+        zty.take()?
             .map(|to_ty| self.unify_expression(to_ty.clone(), expr).map(|()| to_ty))
             .transpose()
     }
@@ -72,6 +74,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         expr: &mut ast::Expression<'ast>,
     ) -> ZVisitorResult {
         use ast::Expression::*;
+        let ty = self.canon_type(ty)?;
         match expr {
             Ternary(te) => self.unify_ternary(ty, te),
             Binary(be) => self.unify_binary(ty, be),
@@ -135,7 +138,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
             }))
         });
         if let Some(ty) = rty {
-            eq_type(ty, &ret_ty)?;
+            self.eq_type(ty, &ret_ty)?;
         }
         Ok(ret_ty)
     }
@@ -187,7 +190,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         pf: &mut ast::PostfixExpression<'ast>,
     ) -> ZVisitorResult {
         let acc_ty = self.get_postfix_ty(pf, Some(&ty))?;
-        eq_type(&ty, &acc_ty)
+        self.eq_type(&ty, &acc_ty)
     }
 
     fn unify_array_initializer(
@@ -239,10 +242,11 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         };
 
         let mut sm_types = self
-            .monomorphize_struct(&st)?
+            .get_struct_or_type(&st.id.value)?
+            .expect("type aliases should have been flattened already")
             .fields
-            .into_iter()
-            .map(|sf| (sf.id.value, sf.ty))
+            .iter()
+            .map(|sf| (sf.id.value.clone(), sf.ty.clone()))
             .collect::<HashMap<String, ast::Type<'ast>>>();
 
         // unify each InlineStructExpression member with field def from struct def'n
@@ -307,7 +311,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         ty: ast::Type<'ast>,
         ie: &mut ast::IdentifierExpression<'ast>,
     ) -> ZVisitorResult {
-        self.lookup_type(ie).and_then(|ity| eq_type(&ty, &ity))
+        self.lookup_type(ie).and_then(|ity| self.eq_type(&ty, &ity))
     }
 
     fn unify_ternary(
@@ -382,7 +386,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                         (Some(lt), Some(rt)) if (matches!(lt, Basic(_)) && matches!(rt, Basic(_))) || matches!(&be.op, Eq | NotEq) => {
                             let lty = lty.unwrap();
                             let rty = rty.unwrap();
-                            eq_type(&lty, &rty)
+                            self.eq_type(&lty, &rty)
                                 .map_err(|e|
                                 ZVisitorError(format!(
                                     "ZStatementWalker: got differing types {:?}, {:?} for lhs, rhs of expr:\n{}\n{}",
@@ -577,6 +581,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                     "ZStatementWalker: tried to walk accesses into a Basic type".to_string(),
                 ));
             }
+            ty = self.canon_type(ty)?;
             ty = match f(acc)? {
                 Select(aacc) => {
                     if let Type::Array(aty) = ty {
@@ -602,7 +607,8 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                 Member(macc) => {
                     // XXX(unimpl) LHS of definitions must make generics explicit
                     if let Type::Struct(sty) = ty {
-                        self.monomorphize_struct(&sty)?
+                        self.get_struct_or_type(&sty.id.value)?
+                            .expect("type aliases should have been flattened already")
                             .fields
                             .iter()
                             .find(|f| f.id.value == macc.id.value)
@@ -729,209 +735,17 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         self.vars.pop();
     }
 
-    fn monomorphize_struct(
-        &self,
-        sty: &ast::StructType<'ast>,
-    ) -> ZResult<ast::StructDefinition<'ast>> {
-        match self.get_struct_or_type(&sty.id.value)? {
-            Ok(strdef) => self.monomorphize_struct_s(sty, strdef.clone()),
-            Err(tydef) => self.monomorphize_struct_t(sty, tydef),
+    // shallow canonicalization: flatten down to the first Basic, Array, or non-alias Struct
+    fn canon_type(&self, ty: ast::Type<'ast>) -> ZResult<ast::Type<'ast>> {
+        use ast::Type::*;
+        match ty {
+            Basic(b) => Ok(ast::Type::Basic(b)),
+            Array(a) => Ok(ast::Type::Array(a)),
+            Struct(s) => match self.get_struct_or_type(&s.id.value)? {
+                Ok(_) => Ok(ast::Type::Struct(s)),
+                Err(tydef) => self.canon_type(tydef.ty.clone()),
+            },
         }
-    }
-
-    fn monomorphize_struct_t(
-        &self,
-        sty: &ast::StructType<'ast>,
-        tydef: &ast::TypeDefinition<'ast>,
-    ) -> ZResult<ast::StructDefinition<'ast>> {
-        // first, recursively monomorphize the inner struct
-        let mut sdef = match &tydef.ty {
-            ast::Type::Basic(_) => Err("Basic"),
-            ast::Type::Array(_) => Err("Array"),
-            ast::Type::Struct(sty_inner) => Ok(sty_inner),
-        }
-        .map_err(|e| {
-            ZVisitorError(format!(
-            "ZStatementWalker: found {} type attempting to struct-monomorphize type alias {}:\n{}",
-            e,
-            &sty.id.value,
-            span_to_string(&sty.span),
-        ))
-        })
-        .and_then(|sty_inner| self.monomorphize_struct(sty_inner))?;
-
-        // short-circuit if there are no generics to apply in this TypeDefinition
-        if tydef.generics.is_empty() {
-            return if sty.explicit_generics.is_some() {
-                Err(ZVisitorError(format!(
-                    "ZStatementWalker: got explicit generics for non-generic type alias {}:\n{}",
-                    &sty.id.value,
-                    span_to_string(&sty.span),
-                )))
-            } else {
-                Ok(sdef)
-            };
-        }
-
-        if sty.explicit_generics.is_none() {
-            return Err(ZVisitorError(format!(
-                "ZStatementWalker: no explicit generics found monomorphizing type alias {}:\n{}",
-                &sty.id.value,
-                span_to_string(&sty.span),
-            )));
-        }
-
-        // monomorphize TypeDefinition generics vs StructType explicit_generics
-        use ast::ConstantGenericValue::*;
-        let gen_values = &sty.explicit_generics.as_ref().unwrap().values;
-        let gvmap = tydef
-            .generics
-            .iter()
-            .map(|ie| ie.value.clone())
-            .zip(gen_values.iter().map(|cgv| match cgv {
-                Underscore(_) => unreachable!(),
-                Value(l) => ast::Expression::Literal(l.clone()),
-                Identifier(i) => ast::Expression::Identifier(i.clone()),
-            }))
-            .collect::<HashMap<String, ast::Expression<'ast>>>();
-
-        let mut sf_rewriter = ZExpressionRewriter::new(gvmap);
-        sdef.fields
-            .iter_mut()
-            .try_for_each(|f| sf_rewriter.visit_struct_field(f))?;
-
-        Ok(sdef)
-    }
-
-    fn monomorphize_struct_s(
-        &self,
-        sty: &ast::StructType<'ast>,
-        mut sdef: ast::StructDefinition<'ast>,
-    ) -> ZResult<ast::StructDefinition<'ast>> {
-        // short circuit for non-generic structs
-        if sdef.generics.is_empty() {
-            return if sty.explicit_generics.is_some() {
-                Err(ZVisitorError(format!(
-                    "ZStatementWalker: got explicit generics for non-generic struct type {}:\n{}",
-                    &sty.id.value,
-                    span_to_string(&sty.span),
-                )))
-            } else {
-                Ok(sdef)
-            };
-        }
-
-        if sty.explicit_generics.is_none() {
-            return Err(ZVisitorError(format!(
-                "ZStatementWalker: no explicit generics found monomorphizing struct {}:\n{}",
-                &sty.id.value,
-                span_to_string(&sty.span),
-            )));
-        }
-
-        let generics = std::mem::take(&mut sdef.generics);
-        let gen_values = &sty.explicit_generics.as_ref().unwrap().values;
-        assert_eq!(generics.len(), gen_values.len());
-
-        use ast::ConstantGenericValue::*;
-        let gvmap = generics
-            .into_iter()
-            .map(|ie| ie.value)
-            .zip(gen_values.iter().map(|cgv| match cgv {
-                Underscore(_) => unreachable!(),
-                Value(l) => ast::Expression::Literal(l.clone()),
-                Identifier(i) => ast::Expression::Identifier(i.clone()),
-            }))
-            .collect::<HashMap<String, ast::Expression<'ast>>>();
-
-        // rewrite struct definition
-        let mut sf_rewriter = ZExpressionRewriter::new(gvmap);
-        sdef.fields
-            .iter_mut()
-            .try_for_each(|f| sf_rewriter.visit_struct_field(f))?;
-
-        Ok(sdef)
-    }
-
-    fn monomorphic_struct_or_type(
-        &self,
-        sty: &mut ast::StructType<'ast>,
-    ) -> ZResult<ast::Type<'ast>> {
-        use ast::ConstantGenericValue as CGV;
-
-        // get the struct definition and return early if we don't have to handle generics
-        let sdef = self.get_struct_or_type(&sty.id.value)?;
-        let generics = match sdef {
-            Ok(strdef) => &strdef.generics,
-            Err(tydef) => &tydef.generics,
-        };
-        if generics.is_empty() {
-            return if sty.explicit_generics.is_some() {
-                Err(ZVisitorError(format!(
-                    "ZStatementWalker: got explicit generics for non-generic struct type {}:\n{}",
-                    &sty.id.value,
-                    span_to_string(&sty.span),
-                )))
-            } else {
-                Ok(ast::Type::Struct(sty.clone()))
-            };
-        }
-
-        // check explicit generics
-        let mut eg = sty
-            .explicit_generics
-            .take()
-            .ok_or_else(|| {
-                ZVisitorError(format!(
-                    "ZStatementWalker: must declare explicit generics for type {} in LHS:\n{}",
-                    &sty.id.value,
-                    span_to_string(&sty.span),
-                ))
-            })
-            .and_then(|eg| {
-                if eg.values.len() != generics.len() {
-                    Err(ZVisitorError(format!(
-                        "ZStatementWalker: wrong number of explicit generics for struct {}:\n{}",
-                        &sty.id.value,
-                        span_to_string(&sty.span),
-                    )))
-                } else if eg.values.iter().any(|v| matches!(v, CGV::Underscore(_))) {
-                    Err(ZVisitorError(format!(
-                        "ZStatementWalker: must specify all generic arguments for LHS struct {}:\n{}",
-                        &sty.id.value,
-                        span_to_string(&sty.span),
-                    )))
-                } else {
-                    // make sure identifiers are actually defined!
-                    eg.values.iter().try_for_each(|v|
-                        if let CGV::Identifier(ie) = v {
-                            if self.const_defined(&ie.value) || self.generic_defined(&ie.value) {
-                                Ok(())
-                            } else {
-                                Err(ZVisitorError(format!(
-                                    "ZStatementWalker: {} undef or non-const in {} generics:\n{}",
-                                    &ie.value,
-                                    &sty.id.value,
-                                    span_to_string(&sty.span),
-                                )))
-                            }
-                        } else {
-                            Ok(())
-                        }
-                    ).map(|_| eg)
-                }
-            })?;
-
-        // rewrite untyped literals
-        let mut rewriter = ZConstLiteralRewriter::new(None);
-        eg.values
-            .iter_mut()
-            .try_for_each(|cgv| rewriter.visit_constant_generic_value(cgv))?;
-
-        // put gen_values back
-        sty.explicit_generics = Some(eg);
-
-        Ok(ast::Type::Struct(sty.clone()))
     }
 }
 
@@ -1047,12 +861,7 @@ impl<'ast, 'ret> ZVisitorMut<'ast> for ZStatementWalker<'ast, 'ret> {
 
     fn visit_typed_identifier(&mut self, ti: &mut ast::TypedIdentifier<'ast>) -> ZVisitorResult {
         ZConstLiteralRewriter::new(None).visit_type(&mut ti.ty)?;
-        let ty = if let ast::Type::Struct(sty) = &mut ti.ty {
-            self.monomorphic_struct_or_type(sty)?
-        } else {
-            ti.ty.clone()
-        };
-        self.insert_var(&ti.identifier.value, ty)?;
+        self.insert_var(&ti.identifier.value, ti.ty.clone())?;
         walk_typed_identifier(self, ti)
     }
 
@@ -1111,7 +920,7 @@ impl<'ast, 'ret> ZVisitorMut<'ast> for ZStatementWalker<'ast, 'ret> {
                 .as_mut()
                 .map(|fexp| self.unify_expression(tty, &mut fexp.0))
                 .unwrap_or(Ok(())),
-            (Some(fty), Some(tty)) => eq_type(&fty, &tty).map_err(|e| {
+            (Some(fty), Some(tty)) => self.eq_type(&fty, &tty).map_err(|e| {
                 ZVisitorError(format!(
                     "typing Range: {}\n{}",
                     e.0,

--- a/src/front/zsharp/zvisit/zstmtwalker/mod.rs
+++ b/src/front/zsharp/zvisit/zstmtwalker/mod.rs
@@ -438,6 +438,12 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         ue: &mut ast::UnaryExpression<'ast>,
     ) -> ZVisitorResult {
         use ast::{BasicType::*, Type::*, UnaryOperator::*};
+        // strict operator applies to any type; expression has same type
+        if let Strict(_) = &ue.op {
+            return self.unify_expression(ty, &mut ue.expression);
+        }
+
+        // remaining unary operators can only take Basic types
         let bt = if let Basic(bt) = ty {
             bt
         } else {
@@ -461,6 +467,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                 )),
                 _ => Ok(Basic(bt)),
             },
+            Strict(_) => unreachable!(),
         }?;
 
         self.unify_expression(ety, &mut ue.expression)

--- a/src/front/zsharp/zvisit/zstmtwalker/mod.rs
+++ b/src/front/zsharp/zvisit/zstmtwalker/mod.rs
@@ -658,7 +658,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
             .get_struct_or_type(id)
             .map(|(m, _)| m)
             .ok_or_else(|| {
-                ZVisitorError(format!("ZStatementWalker: undeclared struct type {}", id))
+                ZVisitorError(format!("ZStatementWalker: undeclared struct type {id}.\nNOTE: If {id} is a struct behind an imported type alias, its definition\n      must also be imported into the module where the alias is used."))
             })
     }
 

--- a/src/front/zsharp/zvisit/zstmtwalker/zexprtyper.rs
+++ b/src/front/zsharp/zvisit/zstmtwalker/zexprtyper.rs
@@ -1,7 +1,7 @@
 //! AST Walker for zokrates_pest_ast
 
 use super::super::eqtype::*;
-use super::super::{bos_to_type, ZVisitorError, ZVisitorMut, ZVisitorResult};
+use super::super::{bos_to_type, ZResult, ZVisitorError, ZVisitorMut, ZVisitorResult};
 use super::ZStatementWalker;
 
 use zokrates_pest_ast as ast;
@@ -16,8 +16,11 @@ impl<'ast, 'ret, 'wlk> ZExpressionTyper<'ast, 'ret, 'wlk> {
         Self { walker, ty: None }
     }
 
-    pub fn take(&mut self) -> Option<ast::Type<'ast>> {
-        self.ty.take()
+    pub fn take(&mut self) -> ZResult<Option<ast::Type<'ast>>> {
+        self.ty
+            .take()
+            .map(|t| self.walker.canon_type(t))
+            .transpose()
     }
 
     fn visit_identifier_expression_t(
@@ -83,14 +86,14 @@ impl<'ast, 'ret, 'wlk> ZVisitorMut<'ast> for ZExpressionTyper<'ast, 'ret, 'wlk> 
     ) -> ZVisitorResult {
         assert!(self.ty.is_none());
         self.visit_expression(&mut te.second)?;
-        let ty2 = self.take();
+        let ty2 = self.take()?;
         self.visit_expression(&mut te.third)?;
-        let ty3 = self.take();
+        let ty3 = self.take()?;
         match (ty2, ty3) {
             (Some(t), None) => self.ty.replace(t),
             (None, Some(t)) => self.ty.replace(t),
             (Some(t1), Some(t2)) => {
-                eq_type(&t1, &t2)?;
+                eq_type(&t1, &t2, self.walker.zgen)?;
                 self.ty.replace(t2)
             }
             (None, None) => None,
@@ -114,14 +117,14 @@ impl<'ast, 'ret, 'wlk> ZVisitorMut<'ast> for ZExpressionTyper<'ast, 'ret, 'wlk> 
             }
             BitXor | BitAnd | BitOr | RightShift | LeftShift | Add | Sub | Mul | Div | Rem => {
                 self.visit_expression(&mut be.left)?;
-                let ty_l = self.take();
+                let ty_l = self.take()?;
                 self.visit_expression(&mut be.right)?;
-                let ty_r = self.take();
+                let ty_r = self.take()?;
                 if let Some(ty) = match (ty_l, ty_r) {
                     (Some(t), None) => Some(t),
                     (None, Some(t)) => Some(t),
                     (Some(t1), Some(t2)) => {
-                        eq_type(&t1, &t2)?;
+                        eq_type(&t1, &t2, self.walker.zgen)?;
                         Some(t2)
                     }
                     (None, None) => None,
@@ -156,6 +159,7 @@ impl<'ast, 'ret, 'wlk> ZVisitorMut<'ast> for ZExpressionTyper<'ast, 'ret, 'wlk> 
         use ast::{BasicType::*, Type::*, UnaryOperator::*};
         assert!(self.ty.is_none());
         self.visit_expression(&mut ue.expression)?;
+        self.ty = self.take()?; // canonicalize
         match &ue.op {
             Pos(_) | Neg(_) => {
                 if let Some(ty) = &self.ty {
@@ -247,7 +251,7 @@ impl<'ast, 'ret, 'wlk> ZVisitorMut<'ast> for ZExpressionTyper<'ast, 'ret, 'wlk> 
         use ast::Type::*;
 
         self.visit_expression(&mut *aie.value)?;
-        if let Some(ty) = self.take() {
+        if let Some(ty) = self.take()? {
             let ty = self.arrayize(ty, aie.count.as_ref().clone(), &aie.span);
             self.ty.replace(Array(ty));
         }
@@ -275,7 +279,7 @@ impl<'ast, 'ret, 'wlk> ZVisitorMut<'ast> for ZExpressionTyper<'ast, 'ret, 'wlk> 
             .iter_mut()
             .try_for_each::<_, ZVisitorResult>(|soe| {
                 self.visit_spread_or_expression(soe)?;
-                if let Some(ty) = self.take() {
+                if let Some(ty) = self.take()? {
                     let (nty, nln) = if matches!(soe, ast::SpreadOrExpression::Expression(_)) {
                         Ok((ty, 1))
                     } else if let ast::Type::Array(mut at) = ty {
@@ -295,7 +299,7 @@ impl<'ast, 'ret, 'wlk> ZVisitorMut<'ast> for ZExpressionTyper<'ast, 'ret, 'wlk> 
                     }?;
 
                     if let Some(acc) = &acc_ty {
-                        eq_type(acc, &nty)?;
+                        eq_type(acc, &nty, self.walker.zgen)?;
                     } else {
                         acc_ty.replace(nty);
                     }

--- a/src/front/zsharp/zvisit/zvmut.rs
+++ b/src/front/zsharp/zvisit/zvmut.rs
@@ -83,6 +83,13 @@ pub trait ZVisitorMut<'ast>: Sized {
         walk_struct_definition(self, structdef)
     }
 
+    fn visit_type_definition(
+        &mut self,
+        structdef: &mut ast::TypeDefinition<'ast>,
+    ) -> ZVisitorResult {
+        walk_type_definition(self, structdef)
+    }
+
     fn visit_struct_field(&mut self, structfield: &mut ast::StructField<'ast>) -> ZVisitorResult {
         walk_struct_field(self, structfield)
     }

--- a/src/front/zsharp/zvisit/zvmut.rs
+++ b/src/front/zsharp/zvisit/zvmut.rs
@@ -54,8 +54,8 @@ pub trait ZVisitorMut<'ast>: Sized {
         walk_from_import_directive(self, fimport)
     }
 
-    fn visit_import_source(&mut self, is: &mut ast::ImportSource<'ast>) -> ZVisitorResult {
-        walk_import_source(self, is)
+    fn visit_any_string(&mut self, is: &mut ast::AnyString<'ast>) -> ZVisitorResult {
+        walk_any_string(self, is)
     }
 
     fn visit_import_symbol(&mut self, is: &mut ast::ImportSymbol<'ast>) -> ZVisitorResult {
@@ -306,6 +306,10 @@ pub trait ZVisitorMut<'ast>: Sized {
     }
 
     fn visit_not_operator(&mut self, _po: &mut ast::NotOperator) -> ZVisitorResult {
+        Ok(())
+    }
+
+    fn visit_strict_operator(&mut self, _so: &mut ast::StrOperator) -> ZVisitorResult {
         Ok(())
     }
 

--- a/src/ir/opt/cfold.rs
+++ b/src/ir/opt/cfold.rs
@@ -10,7 +10,21 @@ use std::sync::RwLock;
 
 lazy_static! {
     // TODO: use weak pointers to allow GC
-    static ref FOLDS: RwLock<TermCache<Term>> = RwLock::new(TermCache::new(TERM_CACHE_LIMIT));
+    static ref FOLDS: RwLock<TermCache<TTerm>> = RwLock::new(TermCache::new(TERM_CACHE_LIMIT));
+}
+
+pub(in super::super) fn collect() {
+    let mut cache_handle = FOLDS.write().unwrap();
+    let cache = cache_handle.deref_mut();
+    let mut to_pop = Vec::new();
+    for (k, v) in cache.iter() {
+        if k.elm.strong_count() == 0 || v.elm.strong_count() == 0 {
+            to_pop.push(k.clone());
+        }
+    }
+    for k in to_pop.into_iter() {
+        cache.pop(&k);
+    }
 }
 
 /// Create a constant boolean
@@ -39,13 +53,13 @@ pub fn fold(node: &Term) -> Term {
 }
 
 /// Do constant-folding backed by a cache.
-pub fn fold_cache(node: &Term, cache: &mut TermCache<Term>) -> Term {
+pub fn fold_cache(node: &Term, cache: &mut TermCache<TTerm>) -> Term {
     // (node, children pushed)
     let mut stack = vec![(node.clone(), false)];
 
     // Maps terms to their rewritten versions.
     while let Some((t, children_pushed)) = stack.pop() {
-        if cache.contains(&t) {
+        if cache.contains(&t.to_weak()) {
             continue;
         }
         if !children_pushed {
@@ -53,7 +67,12 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<Term>) -> Term {
             stack.extend(t.cs.iter().map(|c| (c.clone(), false)));
             continue;
         }
-        let mut c_get = |x: &Term| -> Term { cache.get(x).expect("postorder cache").clone() };
+        let mut c_get = |x: &Term| -> Term {
+            cache
+                .get(&x.to_weak())
+                .and_then(|x| x.to_hconsed())
+                .expect("postorder cache")
+        };
         let mut get = |i: usize| c_get(&t.cs[i]);
         let new_t_opt = match &t.op {
             Op::Not => get(0).as_bool_opt().and_then(|c| cbool(!c)),
@@ -247,13 +266,21 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<Term>) -> Term {
             _ => None,
         };
         let new_t = {
-            let mut cc_get = |x: &Term| -> Term { cache.get(x).expect("postorder cache").clone() };
+            let mut cc_get = |x: &Term| -> Term {
+                cache
+                    .get(&x.to_weak())
+                    .and_then(|x| x.to_hconsed())
+                    .expect("postorder cache")
+            };
             new_t_opt
                 .unwrap_or_else(|| term(t.op.clone(), t.cs.iter().map(|c| cc_get(c)).collect()))
         };
-        cache.put(t, new_t);
+        cache.put(t.to_weak(), new_t.to_weak());
     }
-    cache.get(node).expect("postorder cache").clone()
+    cache
+        .get(&node.to_weak())
+        .and_then(|x| x.to_hconsed())
+        .expect("postorder cache")
 }
 
 fn neg_bool(t: Term) -> Term {

--- a/src/ir/term/mod.rs
+++ b/src/ir/term/mod.rs
@@ -1082,6 +1082,11 @@ const LEN_DECAY_NUM: usize = 15;
 const LEN_DECAY_DEN: usize = 16;
 /// Scan term and type databases only if they've grown in size since last scan
 pub fn maybe_garbage_collect() -> bool {
+    // Don't garbage collect while panicking.
+    // NOTE This function probably shouldn't be called from Drop impls, but let's be safe anyway.
+    if std::thread::panicking() {
+        return false;
+    }
     let mut ran = {
         let mut term_table = TERMS.write().unwrap();
         if term_table.should_collect() {

--- a/src/target/aby/trans.rs
+++ b/src/target/aby/trans.rs
@@ -45,6 +45,20 @@ struct ToABY {
     share_map_output: Vec<String>,
 }
 
+impl Drop for ToABY {
+    fn drop(&mut self) {
+        use std::mem::take;
+        // drop everything that uses a Term
+        drop(take(&mut self.md));
+        self.inputs.clear();
+        self.cache.clear();
+        self.term_to_share_cnt.clear();
+        self.s_map.clear();
+        // clean up
+        garbage_collect();
+    }
+}
+
 impl ToABY {
     fn new(s_map: SharingMap, md: ComputationMetadata, path: &Path, lang: &str) -> Self {
         Self {

--- a/src/target/ilp/trans.rs
+++ b/src/target/ilp/trans.rs
@@ -47,6 +47,13 @@ impl ToMilp {
         }
     }
 
+    /// Take the converted ILP instance and garbage collect
+    fn take_ilp(mut self) -> Ilp {
+        self.cache.clear();
+        garbage_collect();
+        self.ilp
+    }
+
     /// Get a new variable, with name dependent on `d`.
     /// If values are being recorded, `value` must be provided.
     fn fresh_bit<D: Display + ?Sized>(&mut self, ctx: &D) -> Expression {
@@ -669,7 +676,8 @@ pub fn to_ilp(cs: Computation) -> Ilp {
         }
         s => panic!("Cannot optimize term of sort {}", s),
     };
-    converter.ilp
+
+    converter.take_ilp()
 }
 
 #[cfg(test)]

--- a/src/target/r1cs/trans.rs
+++ b/src/target/r1cs/trans.rs
@@ -57,6 +57,15 @@ impl ToR1cs {
         }
     }
 
+    /// Take the converted R1CS instance and garbage collect
+    fn take_r1cs(mut self) -> R1cs<String> {
+        drop(std::mem::take(&mut self.cache));
+        drop(self.values.take());
+        self.public_inputs.clear();
+        garbage_collect();
+        self.r1cs
+    }
+
     /// Get a new variable, with name dependent on `d`.
     /// If values are being recorded, `value` must be provided.
     fn fresh_var<D: Display + ?Sized>(
@@ -956,8 +965,9 @@ pub fn to_r1cs(cs: Computation, modulus: FieldT) -> R1cs<String> {
     for c in assertions {
         converter.assert(c);
     }
-    debug!("r1cs public inputs: {:?}", converter.r1cs.public_idxs,);
-    converter.r1cs
+    debug!("r1cs public inputs: {:?}", converter.r1cs.public_idxs);
+
+    converter.take_r1cs()
 }
 
 #[cfg(test)]

--- a/third_party/ZoKrates/zokrates_parser/src/zokrates.pest
+++ b/third_party/ZoKrates/zokrates_parser/src/zokrates.pest
@@ -3,18 +3,19 @@ file = { SOI ~ NEWLINE* ~ pragma? ~ NEWLINE* ~ symbol_declaration* ~ EOI }
 
 pragma = { "#pragma" ~ "curve" ~ curve }
 curve = @{ (ASCII_ALPHANUMERIC | "_") * }
+string = @{(!"\"" ~ ANY)*}
+quoted_string = _{ "\"" ~ string ~ "\"" }
 
 symbol_declaration = { (import_directive | ty_struct_definition | const_definition | function_definition) ~ NEWLINE* }
 
 import_directive = { main_import_directive | from_import_directive }
-from_import_directive = { "from" ~ "\"" ~ import_source ~ "\"" ~ "import" ~ import_symbol_list ~ NEWLINE* }
-main_import_directive = { "import" ~ "\"" ~ import_source ~ "\"" ~ ("as" ~ identifier)? ~ NEWLINE+ }
-import_source = @{(!"\"" ~ ANY)*}
+from_import_directive = { "from" ~ quoted_string ~ "import" ~ import_symbol_list ~ NEWLINE* }
+main_import_directive = { "import" ~ quoted_string ~ ("as" ~ identifier)? ~ NEWLINE+ }
 import_symbol = { identifier ~ ("as" ~ identifier)? }
 import_symbol_list = _{ import_symbol ~ ("," ~ import_symbol)* }
 function_definition = {"def" ~ identifier ~ constant_generics_declaration? ~ "(" ~ parameter_list ~ ")" ~ return_types ~ ":" ~ NEWLINE* ~ statement* }
 const_definition = {"const" ~ ty ~ identifier ~ "=" ~ expression ~ NEWLINE*}
-return_types = _{ ( "->" ~ ( "(" ~ type_list ~ ")" | ty ))? }
+return_types = _{ ( "->" ~ ( "(" ~ ty_list ~ ")" | ty ))? }
 constant_generics_declaration = _{ "<" ~ constant_generics_list ~ ">" }
 constant_generics_list = _{ identifier ~ ("," ~ identifier)* }
 
@@ -32,7 +33,7 @@ ty_basic = { ty_field | ty_bool | ty_u8 | ty_u16 | ty_u32 | ty_u64 }
 ty_basic_or_struct = { ty_basic | ty_struct }
 ty_array = { ty_basic_or_struct ~ ("[" ~ expression ~ "]")+ }
 ty = { ty_array | ty_basic | ty_struct }
-type_list = _{(ty ~ ("," ~ ty)*)?}
+ty_list = _{(ty ~ ("," ~ ty)*)?}
 // structs
 ty_struct = { identifier ~ explicit_generics? }
 // type definitions
@@ -56,7 +57,7 @@ statement = { (return_statement // does not require subsequent newline
 iteration_statement = { "for" ~ ty ~ identifier ~ "in" ~ expression ~ ".." ~ expression ~ "do" ~ NEWLINE* ~ statement* ~ "endfor"}
 return_statement = { "return" ~ expression_list}
 definition_statement = { typed_identifier_or_assignee_list ~ "=" ~ expression } // declare and assign, so only identifiers are allowed, unlike `assignment_statement`
-expression_statement = {"assert" ~ "(" ~ expression ~ ")"}
+expression_statement = {"assert" ~ "(" ~ expression ~ ("," ~ quoted_string)? ~ ")"}
 
 typed_identifier_or_assignee_list = _{ typed_identifier_or_assignee ~ ("," ~ typed_identifier_or_assignee)* }
 typed_identifier_or_assignee = { typed_identifier | assignee } // we don't use { ty? ~ identifier } as with a single token, it gets parsed as `ty` but we want `identifier`
@@ -153,17 +154,20 @@ op_pow = @{"**"}
 op_not = {"!"}
 op_neg = {"-"}
 op_pos = {"+"}
+op_str = {"#"}
 op_left_shift = @{"<<"}
 op_right_shift = @{">>"}
+op_ternary = {"?" ~ expression ~ ":"}
+
 // `op_pow` is *not* in `op_binary` because its precedence is handled in this parser rather than down the line in precedence climbing
-op_binary = _ { op_or | op_and | op_bit_xor | op_bit_and | op_bit_or | op_left_shift | op_right_shift | op_equal | op_not_equal | op_lte | op_lt | op_gte | op_gt | op_add | op_sub | op_mul | op_div | op_rem }
-op_unary = { op_pos | op_neg | op_not }
+op_binary = _ { op_or | op_and | op_bit_xor | op_bit_and | op_bit_or | op_left_shift | op_right_shift | op_equal | op_not_equal | op_lte | op_lt | op_gte | op_gt | op_add | op_sub | op_mul | op_div | op_rem | op_ternary }
+op_unary = { op_pos | op_neg | op_not | op_str }
 
 WHITESPACE = _{ " " | "\t" | "\\" ~ COMMENT? ~ NEWLINE}
 COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!NEWLINE ~ ANY)*) }
 
 // the ordering of reserved keywords matters: if "as" is before "assert", then "assert" gets parsed as (as)(sert) and incorrectly
 // accepted
-keyword = @{"assert"|"as"|"bool"|"byte"|"const"|"def"|"do"|"else"|"endfor"|"export"|"false"|"field"|"for"|"if"|"then"|"fi"|"import"|"from"|
+keyword = @{"assert"|"as"|"bool"|"const"|"def"|"do"|"else"|"endfor"|"export"|"false"|"field"|"for"|"if"|"then"|"fi"|"import"|"from"|
             "in"|"private"|"public"|"return"|"struct"|"true"|"u8"|"u16"|"u32"|"u64"
             }

--- a/third_party/ZoKrates/zokrates_parser/src/zokrates.pest
+++ b/third_party/ZoKrates/zokrates_parser/src/zokrates.pest
@@ -6,7 +6,7 @@ curve = @{ (ASCII_ALPHANUMERIC | "_") * }
 string = @{(!"\"" ~ ANY)*}
 quoted_string = _{ "\"" ~ string ~ "\"" }
 
-symbol_declaration = { (import_directive | ty_struct_definition | const_definition | function_definition) ~ NEWLINE* }
+symbol_declaration = { (import_directive | ty_struct_definition | const_definition | function_definition | type_definition) ~ NEWLINE* }
 
 import_directive = { main_import_directive | from_import_directive }
 from_import_directive = { "from" ~ quoted_string ~ "import" ~ import_symbol_list ~ NEWLINE* }
@@ -15,6 +15,7 @@ import_symbol = { identifier ~ ("as" ~ identifier)? }
 import_symbol_list = _{ import_symbol ~ ("," ~ import_symbol)* }
 function_definition = {"def" ~ identifier ~ constant_generics_declaration? ~ "(" ~ parameter_list ~ ")" ~ return_types ~ ":" ~ NEWLINE* ~ statement* }
 const_definition = {"const" ~ ty ~ identifier ~ "=" ~ expression ~ NEWLINE*}
+type_definition = {"type" ~ identifier ~ constant_generics_declaration? ~ "=" ~ ty ~ NEWLINE*}
 return_types = _{ ( "->" ~ ( "(" ~ ty_list ~ ")" | ty ))? }
 constant_generics_declaration = _{ "<" ~ constant_generics_list ~ ">" }
 constant_generics_list = _{ identifier ~ ("," ~ identifier)* }

--- a/third_party/ZoKrates/zokrates_pest_ast/src/lib.rs
+++ b/third_party/ZoKrates/zokrates_pest_ast/src/lib.rs
@@ -20,7 +20,7 @@ pub use ast::{
     PostfixExpression, Pragma, PrivateNumber, PrivateVisibility, PublicVisibility, Range,
     RangeOrExpression, ReturnStatement, Span, Spread, SpreadOrExpression, Statement, StrOperator,
     StructDefinition, StructField, StructType, SymbolDeclaration, TernaryExpression, ToExpression,
-    Type, TypedIdentifier, TypedIdentifierOrAssignee, U16NumberExpression, U16Suffix, U16Type,
+    Type, TypeDefinition, TypedIdentifier, TypedIdentifierOrAssignee, U16NumberExpression, U16Suffix, U16Type,
     U32NumberExpression, U32Suffix, U32Type, U64NumberExpression, U64Suffix, U64Type,
     U8NumberExpression, U8Suffix, U8Type, UnaryExpression, UnaryOperator, Underscore, Visibility,
     EOI,
@@ -152,6 +152,7 @@ mod ast {
         Import(ImportDirective<'ast>),
         Constant(ConstantDefinition<'ast>),
         Struct(StructDefinition<'ast>),
+        Type(TypeDefinition<'ast>),
         Function(FunctionDefinition<'ast>),
     }
 
@@ -192,6 +193,16 @@ mod ast {
         pub ty: Type<'ast>,
         pub id: IdentifierExpression<'ast>,
         pub expression: Expression<'ast>,
+        #[pest_ast(outer())]
+        pub span: Span<'ast>,
+    }
+
+    #[derive(Debug, FromPest, PartialEq, Clone)]
+    #[pest_ast(rule(Rule::type_definition))]
+    pub struct TypeDefinition<'ast> {
+        pub id: IdentifierExpression<'ast>,
+        pub generics: Vec<IdentifierExpression<'ast>>,
+        pub ty: Type<'ast>,
         #[pest_ast(outer())]
         pub span: Span<'ast>,
     }


### PR DESCRIPTION
This PR breaks cycles between the term cache and the constant folding machinery. It also adds a couple Drop implementations that explicitly call the garbage collector (the C front-end might want one, too---not sure!)

For Z#, this adds

- a unary operator `#` that strictly evaluates (i.e., constant folds) its argument. As a special case, an assignment's RHS is treated strictly if its LHS is `#( ... )`
- the `condition ? consequent : alternative` flavor of ternary operator - exactly the same as `if foo then bar else baz fi`
- typedefs: `type Foo = field[7]` or whatever.

Typedefs have one limitation: if a typedef `Bar` refers to a struct `Foo` in module A, then to use `Bar` in module B one must also import `Foo`.

@alex-ozdemir: before we land this PR, we should land https://github.com/alex-ozdemir/hashconsing/pull/2 and then I should update Cargo.lock to point to your repo again.