### PR TITLE
concurrency fixes for garbage collection

### DIFF
--- a/src/ir/opt/cfold.rs
+++ b/src/ir/opt/cfold.rs
@@ -39,6 +39,9 @@ fn cbv(b: BitVector) -> Option<Term> {
 
 /// Fold away operators over constants.
 pub fn fold(node: &Term) -> Term {
+    #[cfg(test)]
+    let _lock = super::super::term::COLLECT.read().unwrap();
+
     let mut cache_handle = FOLDS.write().unwrap();
     let cache = cache_handle.deref_mut();
 

--- a/src/ir/opt/cfold.rs
+++ b/src/ir/opt/cfold.rs
@@ -39,7 +39,7 @@ fn cbv(b: BitVector) -> Option<Term> {
 
 /// Fold away operators over constants.
 pub fn fold(node: &Term) -> Term {
-    #[cfg(test)]
+    // lock the collector before locking FOLDS (and, inside fold_cache, TERMS)
     let _lock = super::super::term::COLLECT.read().unwrap();
 
     let mut cache_handle = FOLDS.write().unwrap();

--- a/src/ir/opt/mod.rs
+++ b/src/ir/opt/mod.rs
@@ -47,7 +47,7 @@ pub fn opt<I: IntoIterator<Item = Opt>>(mut cs: Computation, optimizations: I) -
                 scalarize_vars::scalarize_inputs(&mut cs);
             }
             Opt::ConstantFold => {
-                #[cfg(test)]
+                // lock the collector because fold_cache locks TERMS
                 let _lock = super::term::COLLECT.read().unwrap();
 
                 let mut cache = TermCache::new(TERM_CACHE_LIMIT);

--- a/src/ir/opt/mod.rs
+++ b/src/ir/opt/mod.rs
@@ -47,6 +47,9 @@ pub fn opt<I: IntoIterator<Item = Opt>>(mut cs: Computation, optimizations: I) -
                 scalarize_vars::scalarize_inputs(&mut cs);
             }
             Opt::ConstantFold => {
+                #[cfg(test)]
+                let _lock = super::term::COLLECT.read().unwrap();
+
                 let mut cache = TermCache::new(TERM_CACHE_LIMIT);
                 for a in &mut cs.outputs {
                     // allow unbounded size during a single fold_cache call

--- a/src/ir/term/ty.rs
+++ b/src/ir/term/ty.rs
@@ -185,9 +185,8 @@ pub fn check_raw(t: &Term) -> Result<Sort, TypeError> {
         return Ok(s.clone());
     }
 
-    #[cfg(test)]
+    // lock the collector before locking TERM_TYPES
     let _lock = COLLECT.read().unwrap();
-
     let mut term_tys = TERM_TYPES.write().unwrap();
     // to_check is a stack of (node, cs checked) pairs.
     let mut to_check = vec![(t.clone(), false)];
@@ -401,9 +400,8 @@ pub fn rec_check_raw(t: &Term) -> Result<Sort, TypeError> {
         return Ok(s.clone());
     }
 
-    #[cfg(test)]
+    // lock the collector before locking TERM_TYPES
     let _lock = COLLECT.read().unwrap();
-
     let mut term_tys = TERM_TYPES.write().unwrap();
     // to_check is a stack of (node, cs checked) pairs.
     let mut to_check = vec![(t.clone(), false)];

--- a/src/ir/term/ty.rs
+++ b/src/ir/term/ty.rs
@@ -6,7 +6,6 @@ lazy_static! {
     /// Cache of all types
     pub(super) static ref TERM_TYPES: RwLock<TypeTable> = RwLock::new(TypeTable {
         map: FxHashMap::default(),
-        last_len: 0,
     });
 }
 
@@ -185,43 +184,40 @@ pub fn check_raw(t: &Term) -> Result<Sort, TypeError> {
     if let Some(s) = TERM_TYPES.read().unwrap().get(&t.to_weak()) {
         return Ok(s.clone());
     }
-    {
-        let mut term_tys = TERM_TYPES.write().unwrap();
-        // to_check is a stack of (node, cs checked) pairs.
-        let mut to_check = vec![(t.clone(), false)];
-        while !to_check.is_empty() {
-            let back = to_check.last_mut().unwrap();
-            let weak = back.0.to_weak();
-            // The idea here is to check that
-            if let Some((p, _)) = term_tys.get_key_value(&weak) {
-                if p.to_hconsed().is_some() {
-                    to_check.pop();
-                    continue;
-                } else {
-                    term_tys.remove(&weak);
-                }
-            }
-            if !back.1 {
-                back.1 = true;
-                for c in check_dependencies(&back.0) {
-                    to_check.push((c, false));
-                }
+
+    #[cfg(test)]
+    let _lock = COLLECT.read().unwrap();
+
+    let mut term_tys = TERM_TYPES.write().unwrap();
+    // to_check is a stack of (node, cs checked) pairs.
+    let mut to_check = vec![(t.clone(), false)];
+    while !to_check.is_empty() {
+        let back = to_check.last_mut().unwrap();
+        let weak = back.0.to_weak();
+        // The idea here is to check that
+        if let Some((p, _)) = term_tys.get_key_value(&weak) {
+            if p.to_hconsed().is_some() {
+                to_check.pop();
+                continue;
             } else {
-                let ty = check_raw_step(&back.0, &*term_tys).map_err(|reason| TypeError {
-                    op: back.0.op.clone(),
-                    args: vec![], // not quite right
-                    reason,
-                })?;
-                term_tys.insert(back.0.to_weak(), ty);
+                term_tys.remove(&weak);
             }
         }
+        if !back.1 {
+            back.1 = true;
+            for c in check_dependencies(&back.0) {
+                to_check.push((c, false));
+            }
+        } else {
+            let ty = check_raw_step(&back.0, &*term_tys).map_err(|reason| TypeError {
+                op: back.0.op.clone(),
+                args: vec![], // not quite right
+                reason,
+            })?;
+            term_tys.insert(back.0.to_weak(), ty);
+        }
     }
-    Ok(TERM_TYPES
-        .read()
-        .unwrap()
-        .get(&t.to_weak())
-        .unwrap()
-        .clone())
+    Ok(term_tys.get(&t.to_weak()).unwrap().clone())
 }
 
 /// Helper function for rec_check_raw
@@ -404,50 +400,46 @@ pub fn rec_check_raw(t: &Term) -> Result<Sort, TypeError> {
     if let Some(s) = TERM_TYPES.read().unwrap().get(&t.to_weak()) {
         return Ok(s.clone());
     }
-    {
-        let mut term_tys = TERM_TYPES.write().unwrap();
-        // to_check is a stack of (node, cs checked) pairs.
-        let mut to_check = vec![(t.clone(), false)];
-        while !to_check.is_empty() {
-            let back = to_check.last_mut().unwrap();
-            let weak = back.0.to_weak();
-            // The idea here is to check that
-            if let Some((p, _)) = term_tys.get_key_value(&weak) {
-                if p.to_hconsed().is_some() {
-                    to_check.pop();
-                    continue;
-                } else {
-                    term_tys.remove(&weak);
-                }
-            }
-            if !back.1 {
-                back.1 = true;
-                for c in back.0.cs.clone() {
-                    to_check.push((c, false));
-                }
+
+    #[cfg(test)]
+    let _lock = COLLECT.read().unwrap();
+
+    let mut term_tys = TERM_TYPES.write().unwrap();
+    // to_check is a stack of (node, cs checked) pairs.
+    let mut to_check = vec![(t.clone(), false)];
+    while !to_check.is_empty() {
+        let back = to_check.last_mut().unwrap();
+        let weak = back.0.to_weak();
+        // The idea here is to check that
+        if let Some((p, _)) = term_tys.get_key_value(&weak) {
+            if p.to_hconsed().is_some() {
+                to_check.pop();
+                continue;
             } else {
-                let tys = back
-                    .0
-                    .cs
-                    .iter()
-                    .map(|c| term_tys.get(&c.to_weak()).unwrap())
-                    .collect::<Vec<_>>();
-                let ty =
-                    rec_check_raw_helper(&back.0.op, &tys[..]).map_err(|reason| TypeError {
-                        op: back.0.op.clone(),
-                        args: tys.into_iter().cloned().collect(),
-                        reason,
-                    })?;
-                term_tys.insert(back.0.to_weak(), ty);
+                term_tys.remove(&weak);
             }
         }
+        if !back.1 {
+            back.1 = true;
+            for c in back.0.cs.clone() {
+                to_check.push((c, false));
+            }
+        } else {
+            let tys = back
+                .0
+                .cs
+                .iter()
+                .map(|c| term_tys.get(&c.to_weak()).unwrap())
+                .collect::<Vec<_>>();
+            let ty = rec_check_raw_helper(&back.0.op, &tys[..]).map_err(|reason| TypeError {
+                op: back.0.op.clone(),
+                args: tys.into_iter().cloned().collect(),
+                reason,
+            })?;
+            term_tys.insert(back.0.to_weak(), ty);
+        }
     }
-    Ok(TERM_TYPES
-        .read()
-        .unwrap()
-        .get(&t.to_weak())
-        .unwrap()
-        .clone())
+    Ok(term_tys.get(&t.to_weak()).unwrap().clone())
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
@alex-ozdemir reminded me that tests run concurrently, meaning we actually have to worry about deadlocking etc in the garbage collector. Mea culpa.

This PR makes the collector hold one lock (on TERMS, TYPES, or FOLDS) at a time.

It also adds a new lock, COLLECT, only in `#[cfg(test)]`. The collector takes this read-write; constant-folding and type-checking take it read-only. This means that garbage collection can't run while folding or typing is going on, which otherwise could potentially result in terms being collected while they're still needed.