### PR TITLE
Broader SHA bitwise ITE optimization

### DIFF
--- a/src/ir/opt/sha.rs
+++ b/src/ir/opt/sha.rs
@@ -19,31 +19,30 @@ pub fn sha_rewrites(term_: &Term) -> Term {
                     let l = get(0);
                     let r = get(1);
                     if l.op == r.op && l.op == BV_AND && l.cs.len() == 2 && r.cs.len() == 2 {
-                        let opt_match = if let Some(r_i) =
-                            r.cs.iter()
-                                .position(|r_c| r_c == &term![BV_NOT; l.cs[0].clone()])
-                        {
-                            Some((&l.cs[0], &l.cs[1], &r.cs[1 - r_i]))
-                        } else if let Some(r_i) =
-                            r.cs.iter()
-                                .position(|r_c| r_c == &term![BV_NOT; l.cs[1].clone()])
-                        {
-                            Some((&l.cs[1], &l.cs[0], &r.cs[1 - r_i]))
-                        } else if let Some(l_i) =
-                            l.cs.iter()
-                                .position(|l_c| l_c == &term![BV_NOT; r.cs[0].clone()])
-                        {
-                            Some((&r.cs[0], &r.cs[1], &l.cs[1 - l_i]))
-                        } else if let Some(l_i) =
-                            l.cs.iter()
-                                .position(|l_c| l_c == &term![BV_NOT; r.cs[1].clone()])
-                        {
-                            Some((&r.cs[1], &r.cs[0], &l.cs[1 - l_i]))
-                        } else {
-                            None
-                        };
+                        let opt_match = r
+                            .cs
+                            .iter()
+                            .position(|r_c| r_c == &term![BV_NOT; l.cs[0].clone()])
+                            .map(|r_i| (&l.cs[0], &l.cs[1], &r.cs[1 - r_i]))
+                            .or_else(|| {
+                                r.cs.iter()
+                                    .position(|r_c| r_c == &term![BV_NOT; l.cs[1].clone()])
+                                    .map(|r_i| (&l.cs[1], &l.cs[0], &r.cs[1 - r_i]))
+                                    .or_else(|| {
+                                        l.cs.iter()
+                                            .position(|l_c| l_c == &term![BV_NOT; r.cs[0].clone()])
+                                            .map(|l_i| (&r.cs[0], &r.cs[1], &l.cs[1 - l_i]))
+                                            .or_else(|| {
+                                                l.cs.iter()
+                                                    .position(|l_c| {
+                                                        l_c == &term![BV_NOT; r.cs[1].clone()]
+                                                    })
+                                                    .map(|l_i| (&r.cs[1], &r.cs[0], &l.cs[1 - l_i]))
+                                            })
+                                    })
+                            });
                         if let Some((c, t, f)) = opt_match {
-                            if let Sort::BitVector(w) = check(&t) {
+                            if let Sort::BitVector(w) = check(t) {
                                 debug!("SHA CH");
                                 Some(term(
                                 BV_CONCAT,

--- a/src/ir/opt/sha.rs
+++ b/src/ir/opt/sha.rs
@@ -16,28 +16,51 @@ pub fn sha_rewrites(term_: &Term) -> Term {
             // or: (a & b) ^ (~a & c)
             &BV_OR | &BV_XOR => {
                 if t.cs.len() == 2 {
-                    let a = get(0);
-                    let b = get(1);
-                    if a.op == b.op
-                        && a.op == BV_AND
-                        && b.cs[0].op == BV_NOT
-                        && b.cs[0].cs[0] == a.cs[0]
-                    {
-                        if let Sort::BitVector(w) = check(&t) {
-                            debug!("SHA CH");
-                            Some(term(
+                    let l = get(0);
+                    let r = get(1);
+                    if l.op == r.op && l.op == BV_AND && l.cs.len() == 2 && r.cs.len() == 2 {
+                        let opt_match = if let Some(r_i) =
+                            r.cs.iter()
+                                .position(|r_c| r_c == &term![BV_NOT; l.cs[0].clone()])
+                        {
+                            Some((&l.cs[0], &l.cs[1], &r.cs[1 - r_i]))
+                        } else if let Some(r_i) =
+                            r.cs.iter()
+                                .position(|r_c| r_c == &term![BV_NOT; l.cs[1].clone()])
+                        {
+                            Some((&l.cs[1], &l.cs[0], &r.cs[1 - r_i]))
+                        } else if let Some(l_i) =
+                            l.cs.iter()
+                                .position(|l_c| l_c == &term![BV_NOT; r.cs[0].clone()])
+                        {
+                            Some((&r.cs[0], &r.cs[1], &l.cs[1 - l_i]))
+                        } else if let Some(l_i) =
+                            l.cs.iter()
+                                .position(|l_c| l_c == &term![BV_NOT; r.cs[1].clone()])
+                        {
+                            Some((&r.cs[1], &r.cs[0], &l.cs[1 - l_i]))
+                        } else {
+                            None
+                        };
+                        if let Some((c, t, f)) = opt_match {
+                            if let Sort::BitVector(w) = check(&t) {
+                                debug!("SHA CH");
+                                Some(term(
                                 BV_CONCAT,
                                 (0..w)
                                     .map(|i| {
-                                        term![BOOL_TO_BV; term![ITE; term![Op::BvBit(i); a.cs[0].clone()],
-                                                   term![Op::BvBit(i); a.cs[1].clone()],
-                                                   term![Op::BvBit(i); b.cs[1].clone()]]]
+                                        term![BOOL_TO_BV; term![ITE; term![Op::BvBit(i); c.clone()],
+                                                   term![Op::BvBit(i); t.clone()],
+                                                   term![Op::BvBit(i); f.clone()]]]
                                     })
                                     .rev()
                                     .collect(),
                             ))
+                            } else {
+                                unreachable!()
+                            }
                         } else {
-                            unreachable!()
+                            None
                         }
                     } else {
                         None
@@ -134,6 +157,7 @@ mod test {
     use super::*;
     use crate::ir::term::dist::test::*;
     use quickcheck_macros::quickcheck;
+    use text::parse_term;
 
     #[test]
     fn with_or() {
@@ -177,6 +201,35 @@ mod test {
         let tt =
             term![OR; term![AND; a.clone(), b.clone()], term![AND; b, c.clone()], term![AND; c, a]];
         assert_eq!(tt, sha_maj_elim(&t));
+    }
+
+    fn contains_ite(t: &Term) -> bool {
+        PostOrderIter::new(t.clone()).any(|c| c.op == ITE)
+    }
+
+    #[test]
+    fn catch_all_case() {
+        let abc_term_rewrites = |t: &str| -> bool {
+            contains_ite(&sha_rewrites(&parse_term(
+                format!("(declare ((a (bv 4))(b (bv 4))(c (bv 4))) {})", t).as_bytes(),
+            )))
+        };
+        assert!(abc_term_rewrites("(bvor (bvand a b) (bvand (bvnot a) c))"));
+        assert!(abc_term_rewrites("(bvor (bvand b a) (bvand (bvnot a) c))"));
+        assert!(abc_term_rewrites("(bvor (bvand a b) (bvand c (bvnot a)))"));
+        assert!(abc_term_rewrites("(bvor (bvand b a) (bvand c (bvnot a)))"));
+        assert!(abc_term_rewrites("(bvor (bvand (bvnot a) c) (bvand a b))"));
+        assert!(abc_term_rewrites("(bvor (bvand (bvnot a) c) (bvand b a))"));
+        assert!(abc_term_rewrites("(bvor (bvand c (bvnot a)) (bvand a b))"));
+        assert!(abc_term_rewrites("(bvor (bvand c (bvnot a)) (bvand b a))"));
+        assert!(abc_term_rewrites("(bvxor (bvand a b) (bvand (bvnot a) c))"));
+        assert!(abc_term_rewrites("(bvxor (bvand b a) (bvand (bvnot a) c))"));
+        assert!(abc_term_rewrites("(bvxor (bvand a b) (bvand c (bvnot a)))"));
+        assert!(abc_term_rewrites("(bvxor (bvand b a) (bvand c (bvnot a)))"));
+        assert!(abc_term_rewrites("(bvxor (bvand (bvnot a) c) (bvand a b))"));
+        assert!(abc_term_rewrites("(bvxor (bvand (bvnot a) c) (bvand b a))"));
+        assert!(abc_term_rewrites("(bvxor (bvand c (bvnot a)) (bvand a b))"));
+        assert!(abc_term_rewrites("(bvxor (bvand c (bvnot a)) (bvand b a))"));
     }
 
     #[quickcheck]

--- a/src/ir/term/precomp.rs
+++ b/src/ir/term/precomp.rs
@@ -104,3 +104,37 @@ impl PreComp {
         self
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use text::parse_term;
+
+    #[test]
+    fn restrict_to_inputs() {
+        let mut p = PreComp::new();
+        p.add_output("out0".into(), parse_term(b"(declare ((a bool) (b (bv 4))) (and a (= b #b0000)))"));
+        p.add_output("out1".into(), parse_term(b"(declare ((a bool) (b (bv 4))) (xor a true))"));
+        p.add_output("out2".into(), parse_term(b"(declare ((a bool) (b (bv 4))) (bvuge b #b1000))"));
+
+        let mut p_with_a = p.clone();
+        p_with_a.restrict_to_inputs(vec!["a".into()].into_iter().collect());
+        assert_eq!(p_with_a.sequence, vec!["out1"]);
+        assert_eq!(p_with_a.outputs.len(), 1);
+
+        let mut p_with_b = p.clone();
+        p_with_b.restrict_to_inputs(vec!["b".into()].into_iter().collect());
+        assert_eq!(p_with_b.sequence, vec!["out2"]);
+        assert_eq!(p_with_b.outputs.len(), 1);
+
+        let mut p_both = p.clone();
+        p_both.restrict_to_inputs(vec!["a".into(), "b".into()].into_iter().collect());
+        assert_eq!(p_both.sequence, p.sequence);
+        assert_eq!(p_both.outputs.len(), 3);
+
+        let mut p_extra = p.clone();
+        p_extra.restrict_to_inputs(vec!["a".into(), "b".into(), "c".into()].into_iter().collect());
+        assert_eq!(p_extra.sequence, p.sequence);
+        assert_eq!(p_extra.outputs.len(), 3);
+    }
+}

--- a/src/ir/term/text/mod.rs
+++ b/src/ir/term/text/mod.rs
@@ -448,7 +448,8 @@ impl<'src> IrInterp<'src> {
                         assert_eq!(
                             tts.len(),
                             3,
-                            "A decl should have 2 arguments: (let ((v1 s1) ... (vn sn)) t)"
+                            "A decl should have 2 arguments: (declare ((v1 s1) ... (vn sn)) t), found {:#?}",
+                            tts
                         );
                         let bindings = self.decl_list(&tts[1]);
                         let t = self.term(&tts[2]);


### PR DESCRIPTION
It detects bitwise BV ITEs expressed using and XOR/OR of ANDs with a
NOT. Now it triggers more often.

This cuts a few percentage points (~10%) worth of constraints on ZoK's
shaRound circuit.