### PR TITLE
Improve conditional matrix mult with 3 opts

### DIFF
--- a/examples/ZoKrates/pf/mm4_cond.zok
+++ b/examples/ZoKrates/pf/mm4_cond.zok
@@ -1,0 +1,18 @@
+def matmult(field[16] a, field[16] b) -> field[16]:
+          field[16] c = [0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0]
+  
+          for field i in 0..4 do
+                  for field j in 0..4 do
+                          field s = 0
+                          for field k in 0..4 do
+                                  s = s + a[i*4 + k] * b[k*4 + j]
+                          endfor
+                  c[i*4 +j] = s
+                  endfor
+          endfor
+          return c
+  
+def main(public field[16] a, public field[16] b, public field[2] ab, public field init, public field final, private field doc) -> bool:
+          field[16] s = [1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1]
+          s = if (doc == 0) then matmult(s, a) else matmult(s, b) fi
+          return if s[init*4 + final] == 1 then true else false fi

--- a/scripts/zokrates_test.zsh
+++ b/scripts/zokrates_test.zsh
@@ -25,6 +25,14 @@ function r1cs_test {
     measure_time $BIN $zpath r1cs --action count
 }
 
+function r1cs_test_count {
+    zpath=$1
+    threshold=$2
+    o=$($BIN $zpath r1cs --action count)
+    n_constraints=$(echo $o | grep 'Final R1cs size:' | grep -Eo '\b[0-9]+\b')
+    [[ $n_constraints -lt $threshold ]] || (echo "Got $n_constraints, expected < $threshold" && exit 1)
+}
+
 # Test prove workflow, given an example name
 function pf_test {
     ex_name=$1
@@ -43,6 +51,7 @@ function pf_test_isolate {
     rm -rf P V pi
 }
 
+r1cs_test_count ./examples/ZoKrates/pf/mm4_cond.zok 120
 r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/ecc/edwardsAdd.zok
 r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/ecc/edwardsOnCurve.zok
 r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/ecc/edwardsOrderCheck.zok

--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -1825,11 +1825,15 @@ impl<'ast> ZGen<'ast> {
     /*** circify wrapper functions (hides RefCell) ***/
 
     fn circ_enter_condition(&self, cond: Term) {
-        self.circ.borrow_mut().enter_condition(cond).unwrap();
+        if self.isolate_asserts {
+            self.circ.borrow_mut().enter_condition(cond).unwrap();
+        }
     }
 
     fn circ_exit_condition(&self) {
-        self.circ.borrow_mut().exit_condition()
+        if self.isolate_asserts {
+            self.circ.borrow_mut().exit_condition()
+        }
     }
 
     fn circ_condition(&self) -> Term {

--- a/src/ir/opt/cfold.rs
+++ b/src/ir/opt/cfold.rs
@@ -195,20 +195,26 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<TTerm>, ignore: &[Op]) -> T
                 let c = get(0);
                 let t = get(1);
                 let f = get(2);
-                match c.as_bool_opt() {
-                    Some(true) => Some(t),
-                    Some(false) => Some(f),
-                    None => match t.as_bool_opt() {
-                        Some(true) => Some(fold_cache(&term![OR; c, f], cache, ignore)),
-                        Some(false) => Some(fold_cache(&term![AND; neg_bool(c), f], cache, ignore)),
-                        _ => match f.as_bool_opt() {
-                            Some(true) => {
-                                Some(fold_cache(&term![OR; neg_bool(c), t], cache, ignore))
+                if t == f {
+                    Some(t)
+                } else {
+                    match c.as_bool_opt() {
+                        Some(true) => Some(t),
+                        Some(false) => Some(f),
+                        None => match t.as_bool_opt() {
+                            Some(true) => Some(fold_cache(&term![OR; c, f], cache, ignore)),
+                            Some(false) => {
+                                Some(fold_cache(&term![AND; neg_bool(c), f], cache, ignore))
                             }
-                            Some(false) => Some(fold_cache(&term![AND; c, t], cache, ignore)),
-                            _ => None,
+                            _ => match f.as_bool_opt() {
+                                Some(true) => {
+                                    Some(fold_cache(&term![OR; neg_bool(c), t], cache, ignore))
+                                }
+                                Some(false) => Some(fold_cache(&term![AND; c, t], cache, ignore)),
+                                _ => None,
+                            },
                         },
-                    },
+                    }
                 }
             }
             Op::PfNaryOp(o) => Some(o.clone().flatten(t.cs.iter().map(|c| c_get(c)))),

--- a/src/ir/opt/mem/lin.rs
+++ b/src/ir/opt/mem/lin.rs
@@ -125,7 +125,8 @@ mod test {
                     (select (ite true store_1 store_2) c)
                 )
             )
-        ");
+        ",
+        );
         linearize(&mut c);
         assert!(array_free(&c.outputs[0]));
         assert_eq!(3 + 3 + 1 + 3, count_ites(&c.outputs[0]));
@@ -146,12 +147,12 @@ mod test {
                     (select (ite true store_1 store_2) c)
                 )
             )
-        ");
+        ",
+        );
         linearize(&mut c);
         assert!(array_free(&c.outputs[0]));
         assert_eq!(3 + 3 + 1 + 3, count_ites(&c.outputs[0]));
     }
-
 
     #[test]
     fn select_ite_stores_const() {
@@ -168,7 +169,8 @@ mod test {
                     (select (ite true store_1 store_2) c)
                 )
             )
-        ");
+        ",
+        );
         linearize(&mut c);
         assert!(array_free(&c.outputs[0]));
         assert_eq!(3 + 1 + 3, count_ites(&c.outputs[0]));
@@ -189,7 +191,8 @@ mod test {
                     (select (ite true store_1 store_2) c)
                 )
             )
-        ");
+        ",
+        );
         linearize(&mut c);
         assert!(array_free(&c.outputs[0]));
         assert_eq!(3 + 1 + 3, count_ites(&c.outputs[0]));


### PR DESCRIPTION
We received a benchmark from Lef which essentially checked the following:

   (cond ? A*B : A*C)[i] == v

where A, B, C are 4 by 4 matrices, cond is a bool, i is an index, and v a value.

The expected number of constraints is n^3: order 64 , but compile time and constraint count were in the thousands.

I investigated finding a number of things:
* the Z# front-end entered a conditional branch for the ternary, causing the MM to happen in a conditional context
* while the MM has an oblivious access pattern, since `i` is variable, the oblivious pass wasn't really helping
* there were some weird non-constant indices floating around like (ite cond 0 0)

The three optimizations fix these problems:
* If the Z# frontend isn't in assertion isolation mode, don't enter a conditional branch for an ITE
* Constant folding: add the rewrite (ite cond a a) -> a
* Linear-scan array eliminator: for each operation, check if the index is constant. If so, skip the scan (for that access only)