### PR TITLE
Eval Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__
 .mode.txt
 scripts/aby_tests/tests
 /flamegraph*.svg
+.vscode
+/tmp
+/keys

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
 ]
@@ -34,16 +34,16 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -64,6 +64,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ark-curve25519"
+version = "0.3.0"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown",
+ "itertools 0.10.5",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.10.5",
+ "itertools 0.10.5",
+ "num-bigint 0.4.3",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
+dependencies = [
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
+dependencies = [
+ "num-bigint 0.4.3",
+ "num-traits",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest 0.10.5",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/std#7019830e89b69aca059ce7848e53bd99a09efbab"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -97,15 +203,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "az"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f771a5d1f5503f7f4279a30f3643d3421ba149848b89ecaaec0ea2acf04a5ac4"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -118,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "beef"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed554bd50246729a1ec158d08aa3235d1b69d94ad120ebe187e28894787e736"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bellman"
@@ -138,7 +244,7 @@ dependencies = [
  "log",
  "num_cpus",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "rayon",
  "subtle",
 ]
@@ -192,23 +298,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
  "generic-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
 ]
 
 [[package]]
@@ -220,15 +314,9 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -253,10 +341,13 @@ name = "circ"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "ark-curve25519",
+ "ark-ff",
  "bellman",
  "bincode",
  "bls12_381",
  "circ_fields",
+ "curve25519-dalek",
  "env_logger",
  "ff",
  "from-pest",
@@ -267,12 +358,14 @@ dependencies = [
  "hashconsing",
  "ieee754",
  "im",
- "itertools 0.10.3",
+ "itertools 0.10.5",
  "lang-c",
  "lazy_static",
+ "libc",
  "log",
  "logos",
  "lp-solvers",
+ "merlin",
  "pairing",
  "paste",
  "pest",
@@ -286,8 +379,11 @@ dependencies = [
  "rug",
  "serde",
  "serde_json",
+ "smallvec",
  "structopt",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
  "typed-arena",
  "zokrates_parser",
  "zokrates_pest_ast",
@@ -297,6 +393,9 @@ dependencies = [
 name = "circ_fields"
 version = "0.1.0"
 dependencies = [
+ "ark-curve25519",
+ "ark-ff",
+ "ark-serialize",
  "ff",
  "ff-derive-num",
  "ff_derive 0.11.0",
@@ -325,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "coin_cbc"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d4d15b4d7c661692f07a2a268f4b255c2a41777d2bf5470ce329011c11d9c5"
+checksum = "8f86c5252b7b745adc0bc8a724171018dd2fc1e63629f7f8ec2f28a66b0d6ed7"
 dependencies = [
  "coin_cbc_sys",
  "lazy_static",
@@ -335,9 +434,12 @@ dependencies = [
 
 [[package]]
 name = "coin_cbc_sys"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4902c2c164ed74da85aa8472c4a754de1d8164c1fd16d672ec0faf22da482fa9"
+checksum = "085619f8bdc38e24e25c6336ecc3f2e6c0543d67566dff6daef0e32f7ac20f76"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -346,10 +448,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.4"
+name = "cpufeatures"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -357,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -368,42 +479,85 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "digest"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
-name = "either"
-version = "1.6.1"
+name = "digest"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_logger"
@@ -444,23 +598,17 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
  "synstructure",
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -474,7 +622,7 @@ dependencies = [
  "bitvec",
  "byteorder",
  "ff_derive 0.11.1",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -485,9 +633,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e715451ab983be06481e927a275ec12372103ad426c7cb82cebfe14698ed4cf4"
 dependencies = [
  "num-traits",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -496,12 +644,12 @@ version = "0.11.0"
 source = "git+https://github.com/kwantam/ff.git?rev=b3041c177b9ae28095c9ce8347600212252abc83#b3041c177b9ae28095c9ce8347600212252abc83"
 dependencies = [
  "addchain",
- "num-bigint",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -512,19 +660,19 @@ checksum = "717420ad8da706b4e4190f69d3d39fc8ba4075ea33d08dc6f4d1d46ba1203f54"
 dependencies = [
  "addchain",
  "cfg-if",
- "num-bigint",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -559,35 +707,47 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
+ "version_check",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "gmp-mpfr-sys"
-version = "1.4.8"
+version = "1.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d00b0ef965511028498a1668c4a6ef9b0b2501a4a5ab26fb8156408869306e"
+checksum = "ea3f42dadb6c75f122e9aa87e757ef11d4282f664c9f2e6476a9c2c8970f9d19"
 dependencies = [
  "libc",
  "winapi",
@@ -612,15 +772,15 @@ checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "byteorder",
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -672,7 +832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -681,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -709,18 +869,24 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "keccak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "lang-c"
@@ -736,9 +902,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "log"
@@ -751,26 +917,25 @@ dependencies = [
 
 [[package]]
 name = "logos"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427e2abca5be13136da9afdbf874e6b34ad9001dd70f2b103b083a85daa7b345"
+checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a7d287fd2ac3f75b11f19a1c8a874a7d55744bd91f7a1b3e7cf87d4343c36d"
+checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
 dependencies = [
  "beef",
  "fnv",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
  "regex-syntax",
- "syn 1.0.95",
- "utf8-ranges",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -785,18 +950,12 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.5"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32613e41de4c47ab04970c348ca7ae7382cf116625755af070b008a15516a889"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown",
 ]
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
@@ -814,12 +973,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.5.1"
+name = "merlin"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -827,6 +1008,17 @@ name = "num-bigint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -864,24 +1056,24 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.11.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b10983b38c53aebdf33f542c6275b0f58a238129d00c4ae0e6fb59738d783ca"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
-name = "opaque-debug"
-version = "0.2.3"
+name = "overload"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pairing"
@@ -894,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "pest"
@@ -923,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+checksum = "60b75706b9642ebcb34dab3bc7750f811609a0eb1dd8b88c2d15bf628c1c65b2"
 dependencies = [
  "pest",
  "pest_generator",
@@ -933,37 +1125,49 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.1.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+checksum = "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.1.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+checksum = "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
 dependencies = [
- "maplit",
+ "once_cell",
  "pest",
- "sha-1",
+ "sha1",
 ]
 
 [[package]]
 name = "petgraph"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "ppv-lite86"
@@ -978,9 +1182,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
  "version_check",
 ]
 
@@ -990,8 +1194,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
  "version_check",
 ]
 
@@ -1006,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -1030,9 +1234,9 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1046,11 +1250,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
- "proc-macro2 1.0.39",
+ "proc-macro2 1.0.47",
 ]
 
 [[package]]
@@ -1067,7 +1271,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1077,16 +1281,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -1095,7 +1308,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1124,18 +1337,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1144,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -1168,9 +1381,9 @@ dependencies = [
 
 [[package]]
 name = "rug"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f829d980ca193fa33fdd1decaebe72ec07cf2d8afdd0be60b3e5391f18014c91"
+checksum = "203180f444c95eac53586ed04793ecf6454c5d28f9eca8eead815fc19e136c47"
 dependencies = [
  "az",
  "gmp-mpfr-sys",
@@ -1185,10 +1398,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
-name = "ryu"
-version = "1.0.10"
+name = "rustc_version"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "scopeguard"
@@ -1197,30 +1419,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "serde"
-version = "1.0.137"
+name = "semver"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+
+[[package]]
+name = "serde"
+version = "1.0.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -1228,22 +1456,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.8.2"
+name = "sha1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "block-buffer",
- "digest",
- "fake-simd",
- "opaque-debug",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.5",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
 name = "single"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5add732a1ab689845591a1b50339cf5310b563e08dc5813c65991f30369ea2"
+checksum = "9db45bb685b486eec37e0271dcc0dac76eae5e893125f8a4f0511d0a1d29543b"
 dependencies = [
  "failure",
 ]
@@ -1257,6 +1493,12 @@ dependencies = [
  "bitmaps",
  "typenum",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"
@@ -1283,9 +1525,9 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1307,12 +1549,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
  "unicode-ident",
 ]
 
@@ -1322,10 +1564,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
- "unicode-xid 0.2.3",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+ "unicode-xid 0.2.4",
 ]
 
 [[package]]
@@ -1368,22 +1610,89 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1400,27 +1709,27 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -1430,15 +1739,15 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
-name = "utf8-ranges"
-version = "1.0.5"
+name = "valuable"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vec_map"
@@ -1460,9 +1769,15 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -1511,6 +1826,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+ "synstructure",
+]
+
+[[package]]
 name = "zokrates_parser"
 version = "0.2.4"
 dependencies = [
@@ -1528,3 +1864,18 @@ dependencies = [
  "pest-ast",
  "zokrates_parser",
 ]
+
+[[patch.unused]]
+name = "ark-algebra-bench-templates"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
+
+[[patch.unused]]
+name = "ark-algebra-test-templates"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
+
+[[patch.unused]]
+name = "ark-r1cs-std"
+version = "0.3.1"
+source = "git+https://github.com/arkworks-rs/r1cs-std#4fbdc2b6a5c27aebd7210b34fa25575309494cdf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,16 +1760,6 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "ark-algebra-bench-templates"
-version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
-
-[[patch.unused]]
-name = "ark-algebra-test-templates"
-version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/algebra#3835af548d929d08f3ff1771c4349ed49c698efd"
-
-[[patch.unused]]
 name = "ark-r1cs-std"
 version = "0.3.1"
 source = "git+https://github.com/arkworks-rs/r1cs-std#4fbdc2b6a5c27aebd7210b34fa25575309494cdf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,8 +382,6 @@ dependencies = [
  "smallvec",
  "structopt",
  "thiserror",
- "tracing",
- "tracing-subscriber",
  "typed-arena",
  "zokrates_parser",
  "zokrates_pest_ast",
@@ -994,16 +992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,12 +1056,6 @@ name = "once_cell"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pairing"
@@ -1156,12 +1138,6 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pkg-config"
@@ -1467,15 +1443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "single"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,73 +1596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
-dependencies = [
- "cfg-if",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
-dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
- "syn 1.0.103",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
-dependencies = [
- "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
-dependencies = [
- "nu-ansi-term",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing-core",
- "tracing-log",
-]
-
-[[package]]
 name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,12 +1642,6 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ structopt = "0.3"
 approx = "0.5.0"
 
 [features]
-default = ["bls12381", "ff_dfl", "r1cs", "lp", "smt", "zok"]
+default = ["bls12381", "ff_dfl"]
 bls12381 = []
 ff_dfl = []
 dalek = []
@@ -101,7 +101,5 @@ opt-level = 3
 ark-ec = { git = "https://github.com/arkworks-rs/algebra" }
 ark-ff = { git = "https://github.com/arkworks-rs/algebra" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra" }
-ark-algebra-bench-templates = { git = "https://github.com/arkworks-rs/algebra" }
-ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra" }
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std" }
 ark-std = { git = "https://github.com/arkworks-rs/std" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,6 @@ good_lp = { version = "1.1", features = ["lp-solvers", "coin_cbc"], default-feat
 group = "0.11"
 lp-solvers = { version = "0.0.4", optional = true }
 serde_json = "1.0"
-serde = { version = "1.0", features = ["derive", "rc"] }
-bincode = "1"
 lang-c = { version = "0.10.1", optional = true}
 logos = "0.12"
 pairing = "0.21"
@@ -42,6 +40,16 @@ itertools = "0.10"
 petgraph = "0.6"
 paste = "1.0"
 im = "15"
+merlin = "3.0.0"
+curve25519-dalek = {version = "3.2.0", features = ["serde"]}
+serde = { version = "1.0.124", features = ["derive"] }
+bincode = "1.2.1"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+smallvec = "1.9.0"
+libc = "0.2"
+ark-curve25519 = { path = "./third_party/curve25519" }
+ark-ff = "0.3.0"
 
 [dev-dependencies]
 quickcheck = "1"
@@ -52,9 +60,10 @@ structopt = "0.3"
 approx = "0.5.0"
 
 [features]
-default = ["bls12381", "ff_dfl"]
+default = ["bls12381", "ff_dfl", "r1cs", "lp", "smt", "zok"]
 bls12381 = []
 ff_dfl = []
+dalek = []
 c = ["lang-c"]
 lp = ["good_lp", "lp-solvers"]
 r1cs = ["bellman"]
@@ -63,6 +72,10 @@ zok = ["zokrates_parser", "zokrates_pest_ast"]
 
 [[example]]
 name = "circ"
+
+[[example]]
+name = "run_zok"
+required-features = ["r1cs"]
 
 [[example]]
 name = "zk"
@@ -82,3 +95,15 @@ required-features = ["lp"]
 
 [profile.release]
 debug = true
+
+[profile.test]
+opt-level = 3
+
+[patch.crates-io]
+ark-ec = { git = "https://github.com/arkworks-rs/algebra" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra" }
+ark-algebra-bench-templates = { git = "https://github.com/arkworks-rs/algebra" }
+ark-algebra-test-templates = { git = "https://github.com/arkworks-rs/algebra" }
+ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std" }
+ark-std = { git = "https://github.com/arkworks-rs/std" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,6 @@ merlin = "3.0.0"
 curve25519-dalek = {version = "3.2.0", features = ["serde"]}
 serde = { version = "1.0.124", features = ["derive"] }
 bincode = "1.2.1"
-tracing = "0.1"
-tracing-subscriber = "0.3"
 smallvec = "1.9.0"
 libc = "0.2"
 ark-curve25519 = { path = "./third_party/curve25519" }

--- a/circ_fields/Cargo.lock
+++ b/circ_fields/Cargo.lock
@@ -8,9 +8,126 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ark-curve25519"
+version = "0.3.0"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#402e7f9603fca7a68b86baf296b6feaf904939f5"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown",
+ "itertools",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#402e7f9603fca7a68b86baf296b6feaf904939f5"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest",
+ "itertools",
+ "num-bigint 0.4.3",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#402e7f9603fca7a68b86baf296b6feaf904939f5"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#402e7f9603fca7a68b86baf296b6feaf904939f5"
+dependencies = [
+ "num-bigint 0.4.3",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#402e7f9603fca7a68b86baf296b6feaf904939f5"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#402e7f9603fca7a68b86baf296b6feaf904939f5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#402e7f9603fca7a68b86baf296b6feaf904939f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/std#7019830e89b69aca059ce7848e53bd99a09efbab"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -21,9 +138,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "az"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f771a5d1f5503f7f4279a30f3643d3421ba149848b89ecaaec0ea2acf04a5ac4"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "bitvec"
@@ -53,9 +170,10 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "circ_fields"
 version = "0.1.0"
 dependencies = [
+ "ark-curve25519",
  "ff",
  "ff-derive-num",
- "ff_derive 0.11.0 (git+https://github.com/kwantam/ff.git?rev=b3041c177b9ae28095c9ce8347600212252abc83)",
+ "ff_derive 0.11.0",
  "lazy_static",
  "num-traits",
  "paste",
@@ -65,14 +183,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff"
-version = "0.11.0"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+dependencies = [
+ "crypto-common",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "ff"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
 dependencies = [
  "bitvec",
  "byteorder",
- "ff_derive 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff_derive 0.11.1",
  "rand_core",
  "subtle",
 ]
@@ -92,11 +246,10 @@ dependencies = [
 [[package]]
 name = "ff_derive"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a923972863adcef93ac7092c9bf6543a26e922c1bd6c925518156411e05bf85c"
+source = "git+https://github.com/kwantam/ff.git?rev=b3041c177b9ae28095c9ce8347600212252abc83#b3041c177b9ae28095c9ce8347600212252abc83"
 dependencies = [
  "addchain",
- "num-bigint",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
  "proc-macro2",
@@ -106,11 +259,13 @@ dependencies = [
 
 [[package]]
 name = "ff_derive"
-version = "0.11.0"
-source = "git+https://github.com/kwantam/ff.git?rev=b3041c177b9ae28095c9ce8347600212252abc83#b3041c177b9ae28095c9ce8347600212252abc83"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "717420ad8da706b4e4190f69d3d39fc8ba4075ea33d08dc6f4d1d46ba1203f54"
 dependencies = [
  "addchain",
- "num-bigint",
+ "cfg-if",
+ "num-bigint 0.3.3",
  "num-integer",
  "num-traits",
  "proc-macro2",
@@ -125,10 +280,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
-name = "getrandom"
-version = "0.2.5"
+name = "generic-array"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -137,12 +302,30 @@ dependencies = [
 
 [[package]]
 name = "gmp-mpfr-sys"
-version = "1.4.7"
+version = "1.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a146a7357ce9573bdcc416fc4a99b960e166e72d8eaffa7c59966d51866b5bfb"
+checksum = "ea3f42dadb6c75f122e9aa87e757ef11d4282f664c9f2e6476a9c2c8970f9d19"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -153,9 +336,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "num-bigint"
@@ -169,10 +352,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
+name = "num-bigint"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -180,18 +374,24 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.6"
+name = "once_cell"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "ppv-lite86"
@@ -201,18 +401,18 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -246,18 +446,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rug"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac804305677221f4c82469fd7eb8bfe00dd01420aa191197cb87d738520feef"
+checksum = "203180f444c95eac53586ed04793ecf6454c5d28f9eca8eead815fc19e136c47"
 dependencies = [
  "az",
  "gmp-mpfr-sys",
@@ -266,19 +466,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.136"
+name = "rustc_version"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+
+[[package]]
+name = "serde"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -293,12 +508,24 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
  "unicode-xid",
 ]
 
@@ -309,16 +536,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "typenum"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -350,3 +595,39 @@ checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[patch.unused]]
+name = "ark-algebra-bench-templates"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#402e7f9603fca7a68b86baf296b6feaf904939f5"
+
+[[patch.unused]]
+name = "ark-algebra-test-templates"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/algebra#402e7f9603fca7a68b86baf296b6feaf904939f5"
+
+[[patch.unused]]
+name = "ark-r1cs-std"
+version = "0.3.1"
+source = "git+https://github.com/arkworks-rs/r1cs-std#4fbdc2b6a5c27aebd7210b34fa25575309494cdf"

--- a/circ_fields/Cargo.toml
+++ b/circ_fields/Cargo.toml
@@ -14,6 +14,9 @@ paste = "1.0"
 rand = "0.8"
 rug = { version = "1.11", features = ["serde"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
+ark-curve25519 = { path = "../third_party/curve25519" }
+ark-ff = "0.3.0"
+ark-serialize = "0.3.0"
 
 [dev-dependencies]
 rand = "0.8"

--- a/circ_fields/src/lib.rs
+++ b/circ_fields/src/lib.rs
@@ -52,7 +52,7 @@ pub enum FieldT {
 
 lazy_static! {
     /// Field modulus
-    pub static ref F_CURVE25519_FMOD: Integer = bigint_to_int(Fr::MODULUS);
+    pub static ref F_CURVE25519_FMOD: Integer = Integer::from_digits(&Fr::MODULUS.to_bytes_be(), Order::MsfBe);
     /// Field modulus arc
     pub static ref F_CURVE25519_FMOD_ARC: Arc<Integer> = Arc::new(F_CURVE25519_FMOD.clone());
 }
@@ -470,14 +470,4 @@ impl Into<Integer> for &FieldV {
             FieldV::IntField(i) => i.i.clone(),
         }
     }
-}
-
-/// convert BigInt from ark to Integer from rug
-pub fn bigint_to_int<const N: usize>(i: BigInt<N>) -> Integer {
-    Integer::from_digits(&i.to_bytes_be(), Order::MsfBe)
-}
-
-/// convert Integer from rug to BigInt from ark
-pub fn int_to_bigint<const N: usize>(i: Integer) -> BigInt<N> {
-    BigInt::from_bits_be(&i.to_digits(Order::MsfBe))
 }

--- a/examples/run_zok.rs
+++ b/examples/run_zok.rs
@@ -1,0 +1,95 @@
+use std::path::PathBuf;
+use bls12_381::Bls12;
+use circ::front::{FrontEnd, Mode};
+use circ::front::zsharp::{ZSharpFE, Inputs};
+use circ::ir::term::precomp::PreComp;
+use circ::target::r1cs::bellman::test_prove;
+use circ::target::r1cs::opt::reduce_linearities;
+use circ::target::r1cs::trans::to_r1cs;
+use circ::util::field::DFL_T;
+use circ::ir::opt::{opt, Opt, precomp_opt};
+use std::time::{Instant};
+use circ::ir::term::{Value, BitVector, Computation, Computations};
+use fxhash::FxHashMap as HashMap;
+use rug::Integer;
+use circ_fields::FieldT;
+
+fn main() {
+    env_logger::init();
+    test_sha_round();
+}
+
+fn test_sha_round() {
+    let inputs = Inputs {
+        file: PathBuf::from("./third_party/ZoKrates/zokrates_stdlib/stdlib/hashes/sha256/shaRound.zok"),
+        mode: Mode::Proof,
+        isolate_asserts: true,
+    };
+    let cs = ZSharpFE::gen(inputs);
+    println!("gen finish");
+    let timer = Instant::now();
+    let cs = default_opt(cs);
+    println!("opt finish {}", timer.elapsed().as_millis());
+    let mut input_map = HashMap::<String, Value>::default();
+    map_u32_arr(&[1; 16], "input", &mut input_map);
+    map_u32_arr(&[0; 8], "current", &mut input_map);
+    evaluate_cs(cs.comps["main"].clone(), &input_map);
+}
+
+fn evaluate_cs(cs: Computation, input_map: &HashMap::<String, Value>) {
+    println!("will generate r1cs");
+    let (r1cs, prover_data, _) = to_r1cs(cs, FieldT::from(DFL_T.modulus()));
+    let r1cs = reduce_linearities(r1cs, Some(50));
+    let timer = Instant::now();
+    let _ = prover_data.precompute.eval(input_map);
+    println!("original eval: {}", timer.elapsed().as_millis());
+    println!("r1cs timer {}", timer.elapsed().as_millis());
+    println!("r1cs constraints {}", r1cs.constraints().len());
+    let precomp = precomp_opt(
+        prover_data.precompute,
+        vec![
+            Opt::ConstantFold(Box::new([])),
+            Opt::Obliv,
+        ]
+    ); 
+    println!("after precomp opt");
+    let (term_arr, name_idxes) = precomp.eval_preprocess(&r1cs);
+    let map = PreComp::real_eval(&name_idxes, &term_arr, input_map);
+    test_prove::<Bls12>(&r1cs, &map);
+}
+
+fn map_u32_arr(u32_arr: &[u32], name: &str, input_map: &mut HashMap::<String, Value>) {
+    for (i, b) in u32_arr.iter().enumerate() {
+        input_map.insert(format!("{}.{}", name, i), u32_to_value(*b as u32));
+    }
+}
+
+fn u32_to_value(num: u32) -> Value {
+    Value::BitVector(BitVector::new(Integer::from(num), 32))
+}
+
+fn default_opt(cs: Computations) -> Computations {
+    opt(
+        cs,
+        vec![
+            Opt::ScalarizeVars,
+            Opt::Flatten,
+            // Opt::Sha,
+            Opt::ConstantFold(Box::new([])),
+            Opt::Flatten,
+            Opt::Inline,
+            // Tuples must be eliminated before oblivious array elim
+            Opt::Tuple,
+            Opt::ConstantFold(Box::new([])),
+            Opt::Obliv,
+            // The obliv elim pass produces more tuples, that must be eliminated
+            Opt::Tuple,
+            Opt::LinearScan,
+            // The linear scan pass produces more tuples, that must be eliminated
+            Opt::Tuple,
+            Opt::Flatten,
+            Opt::ConstantFold(Box::new([])),
+            Opt::Inline,
+        ],
+    )
+}

--- a/src/ir/opt/mem/lin.rs
+++ b/src/ir/opt/mem/lin.rs
@@ -83,6 +83,16 @@ impl RewritePass for Linearizer {
             _ => None,
         }
     }
+
+    fn visit_precomp<F: Fn() -> Vec<Term>>(
+        &mut self,
+        orig: &Term,
+        rewritten_children: F,
+    ) -> Option<Term> {
+        let _ = orig;
+        let _ = rewritten_children;
+        todo!()
+    }
 }
 
 /// Eliminate arrays using linear scans. See module documentation.

--- a/src/ir/opt/mem/ram.rs
+++ b/src/ir/opt/mem/ram.rs
@@ -301,6 +301,16 @@ impl RewritePass for Extactor {
             }
         }
     }
+
+    fn visit_precomp<F: Fn() -> Vec<Term>>(
+        &mut self,
+        orig: &Term,
+        rewritten_children: F,
+    ) -> Option<Term> {
+        let _ = orig;
+        let _ = rewritten_children;
+        todo!()
+    }
 }
 
 /// Find arrays which are RAMs (i.e., accessed with a linear sequences of

--- a/src/ir/opt/scalarize_vars.rs
+++ b/src/ir/opt/scalarize_vars.rs
@@ -79,6 +79,16 @@ impl RewritePass for Pass {
             None
         }
     }
+
+    fn visit_precomp<F: Fn() -> Vec<Term>>(
+        &mut self,
+        orig: &Term,
+        rewritten_children: F,
+    ) -> Option<Term> {
+        let _ = orig;
+        let _ = rewritten_children;
+        todo!()
+    }
 }
 
 /// Run the tuple elimination pass.

--- a/src/ir/term/precomp.rs
+++ b/src/ir/term/precomp.rs
@@ -3,9 +3,16 @@
 //! Conceptually, this machinery allows a party with input material for one computation to map it
 //! into input material for another computation.
 
-use fxhash::{FxHashMap, FxHashSet};
+// use std::time::Instant;
 
-use crate::ir::term::*;
+use std::{time::Instant};
+
+use fxhash::{FxHashMap, FxHashSet};
+use itertools::Itertools;
+// use std::time::{Instant};
+
+use crate::{ir::term::*, target::r1cs::R1cs};
+use smallvec::SmallVec;
 
 /// A "precomputation".
 ///
@@ -13,8 +20,9 @@ use crate::ir::term::*;
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreComp {
     /// A map from output names to the terms that compute them.
-    outputs: FxHashMap<String, Term>,
-    sequence: Vec<String>,
+    pub outputs: FxHashMap<String, Term>,
+    /// The sequence of output names
+    pub sequence: Vec<String>,
 }
 
 impl PreComp {
@@ -58,10 +66,46 @@ impl PreComp {
             !drop
         });
     }
-    /// Evaluate the precomputation.
-    ///
-    /// Requires an input environment that binds all inputs for the underlying computation.
-    pub fn eval(&self, env: &FxHashMap<String, Value>) -> FxHashMap<String, Value> {
+
+    /// transform Term to NumTerm
+    pub fn transform_terms(
+        &self,
+        index_cache: &mut TermMap<usize>,
+        term_arr: &mut Vec<NumTerm>,
+    ) {
+
+        for o_name in &self.sequence {
+            let t = self.outputs.get(o_name).unwrap();
+            let mut stack = vec![(false, t.clone())];
+            while let Some((children_pushed, node)) = stack.pop() {
+                if index_cache.contains_key(&node) {
+                    continue;
+                }
+                if children_pushed {
+                    let mut cs_arr = SmallVec::<[usize; 3]>::new();
+                    for child in &node.cs {
+                        cs_arr.push(*index_cache.get(child).unwrap());
+                    }
+                    let new_num_term = NumTerm {
+                        op: NumOp::Op(node.op.clone()),
+                        cs: cs_arr,
+                    };
+                    index_cache.insert(node, term_arr.len());
+                    term_arr.push(new_num_term);
+                } else {
+                    stack.push((true, node.clone()));
+                    for c in &node.cs {
+                        if !index_cache.contains_key(c) {
+                            stack.push((false, c.clone()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// function
+    pub fn eval(&self, env: &FxHashMap<String, Value>) -> FxHashMap<String, Value>{
         let mut value_cache: TermMap<Value> = TermMap::new();
         let mut env = env.clone();
         // iterate over all terms, evaluating them using the cache.
@@ -72,6 +116,52 @@ impl PreComp {
         }
         env
     }
+
+    /// eval preprocess
+    pub fn eval_preprocess(
+        &self,
+        r1cs: &R1cs<String>,
+    ) -> (Vec<NumTerm>, FxHashMap<String, usize>) {
+        let mut term_arr = Vec::<NumTerm>::new();
+        let mut index_cache = TermMap::<usize>::new();
+        self.transform_terms(&mut index_cache, &mut term_arr);
+        for term in &mut term_arr {
+            if let NumOp::Op(op) = &term.op {
+                if let Op::Var(o_name, _) = op {
+                    if let Some(o) = self.outputs.get(o_name) {
+                        let term_idx = *index_cache.get(o).unwrap();
+                        term.op = NumOp::Var(term_idx);
+                    }
+                }
+            } else {
+                panic!("Op should not be transformed here!");
+            }
+        }
+        let mut name_idxes = FxHashMap::default();
+        for (_, name) in r1cs.idxs_signals.iter().sorted() {
+            let o = self.outputs.get(name).unwrap();
+            let term_idx = *index_cache.get(o).unwrap();
+            name_idxes.insert(name.clone(), term_idx);
+        }
+        (term_arr, name_idxes)
+    }
+
+    /// real evaluation
+    pub fn real_eval(name_idxes: &FxHashMap<String, usize>, term_arr: &Vec<NumTerm>, env: &FxHashMap<String, Value>) -> FxHashMap<String, Value> {
+        let t1 = Instant::now();
+        let mut val_arr = vec![Option::None; term_arr.len()];
+        for term_idx in 0..term_arr.len() {
+            eval_value_efficient(term_idx, term_arr, &mut val_arr, env);
+        }
+        println!("real eval take {}", t1.elapsed().as_millis());
+        let mut map = FxHashMap::default();
+        for (name, idx) in name_idxes {
+            map.insert(name.clone(), val_arr[*idx].clone().unwrap());
+        }
+        println!("all eval take {}", t1.elapsed().as_millis());
+        map
+    }
+
     /// Compute the inputs for this precomputation
     pub fn inputs_to_terms(&self) -> FxHashMap<String, Term> {
         PostOrderIter::new(term(Op::Tuple, self.outputs.values().cloned().collect()))

--- a/src/ir/term/precomp.rs
+++ b/src/ir/term/precomp.rs
@@ -151,7 +151,7 @@ impl PreComp {
         let t1 = Instant::now();
         let mut val_arr = vec![Option::None; term_arr.len()];
         for term_idx in 0..term_arr.len() {
-            eval_value_efficient(term_idx, term_arr, &mut val_arr, env);
+            eval_value(&mut EvalMode::Preprocessed(term_arr, &mut val_arr, term_idx), env);
         }
         println!("real eval take {}", t1.elapsed().as_millis());
         let mut map = FxHashMap::default();

--- a/src/target/r1cs/bellman.rs
+++ b/src/target/r1cs/bellman.rs
@@ -262,12 +262,14 @@ where
     Ok(())
 }
 
-/// document
+/// Given
+/// * a r1cs instance
+/// * an assignment of the r1cs instance
+/// test the generation of a proof for this r1cs instance
 pub fn test_prove<E: Engine>(r1cs: &R1cs<String>, map: &FxHashMap<String, Value>)
 where
     E::Fr: PrimeFieldBits,
-    E::G1: WnafGroup,
-    E::G2: WnafGroup,
+    E::G1: WnafGroup,    E::G2: WnafGroup,
 {
     let rng = &mut rand::thread_rng();
     let pk = generate_random_parameters::<E, _, _>(SynthInput(r1cs, &None), rng).unwrap();

--- a/src/target/r1cs/bellman.rs
+++ b/src/target/r1cs/bellman.rs
@@ -262,6 +262,18 @@ where
     Ok(())
 }
 
+/// document
+pub fn test_prove<E: Engine>(r1cs: &R1cs<String>, map: &FxHashMap<String, Value>)
+where
+    E::Fr: PrimeFieldBits,
+    E::G1: WnafGroup,
+    E::G2: WnafGroup,
+{
+    let rng = &mut rand::thread_rng();
+    let pk = generate_random_parameters::<E, _, _>(SynthInput(r1cs, &None), rng).unwrap();
+    let _ = create_random_proof(SynthInput(r1cs, &Some(map.clone())), &pk, rng).unwrap();
+}
+
 /// Given
 /// * a verifying-key path,
 /// * a proof path,

--- a/src/target/r1cs/mod.rs
+++ b/src/target/r1cs/mod.rs
@@ -21,10 +21,13 @@ pub mod trans;
 /// A Rank 1 Constraint System.
 pub struct R1cs<S: Hash + Eq> {
     modulus: FieldT,
-    signal_idxs: HashMap<S, usize>,
-    idxs_signals: HashMap<usize, S>,
+    /// variable name to index
+    pub signal_idxs: HashMap<S, usize>,
+    /// index to variable name
+    pub idxs_signals: HashMap<usize, S>,
     next_idx: usize,
-    public_idxs: HashSet<usize>,
+    /// public idxs
+    pub public_idxs: HashSet<usize>,
     constraints: Vec<(Lc, Lc, Lc)>,
     terms: Vec<Term>,
 }
@@ -32,8 +35,11 @@ pub struct R1cs<S: Hash + Eq> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// A linear combination
 pub struct Lc {
+    /// comment
     modulus: FieldT,
+    /// comment
     constant: FieldV,
+    /// comment
     monomials: HashMap<usize, FieldV>,
 }
 
@@ -427,6 +433,7 @@ impl R1cs<String> {
         for o in precompute.outputs().keys() {
             precompute_inputs.remove(o);
         }
+        
         ProverData {
             precompute_inputs,
             precompute,

--- a/third_party/curve25519/Cargo.toml
+++ b/third_party/curve25519/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ark-curve25519"
+version = "0.3.0"
+authors = [ "arkworks contributors" ]
+description = "The curve25519 Montgomery curve"
+homepage = "https://arkworks.rs"
+repository = "https://github.com/arkworks-rs/curves"
+documentation = "https://docs.rs/ark-curve25519/"
+keywords = ["cryptography", "finite-fields", "elliptic-curves" ]
+categories = ["cryptography"]
+include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
+license = "MIT/Apache-2.0"
+edition = "2021"
+
+[dependencies]
+ark-ff = { version = "^0.3.0", default-features = false }
+ark-ec = { version = "^0.3.0", default-features = false }
+ark-std = { version = "^0.3.0", default-features = false }
+ark-r1cs-std = { version = "^0.3.0", default-features = false, optional = true }
+
+[dev-dependencies]
+ark-relations = { version = "^0.3.0", default-features = false }
+ark-serialize = { version = "^0.3.0", default-features = false }
+ark-algebra-test-templates = { version = "^0.3.0", default-features = false }
+
+[features]
+default = []
+std = [ "ark-std/std", "ark-ff/std", "ark-ec/std" ]
+r1cs = [ "ark-r1cs-std" ]

--- a/third_party/curve25519/LICENSE-APACHE
+++ b/third_party/curve25519/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/third_party/curve25519/LICENSE-MIT
+++ b/third_party/curve25519/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/third_party/curve25519/scripts/fr.ipynb
+++ b/third_party/curve25519/scripts/fr.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "04264893",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = 7237005577332262213973186563042994240857116359379907606001950938285454250989"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1603b293",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2^2 * 3 * 11 * 198211423230930754013084525763697 * 276602624281642239937218680557139826668747"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "factor(r - 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "425ceac7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7237005577332262213973186563042994240857116359379907606001950938285454250988\n",
+      "1570463851528226261927580272323658009530148727742783848239914322803198255651\n",
+      "4908983020090465803374304318106080751443647916949975825112097080460587568629\n",
+      "7119675135705137915307919240607293966034195415655343409829245710729128040338\n",
+      "2975531125133123119648879457563281269120703404158613135195788908093573672641\n"
+     ]
+    }
+   ],
+   "source": [
+    "gen = 2\n",
+    "print(pow(gen, (r - 1) / 2, r))\n",
+    "print(pow(gen, (r - 1) / 3, r))\n",
+    "print(pow(gen, (r - 1) / 11, r))\n",
+    "print(pow(gen, (r - 1) / 198211423230930754013084525763697, r))\n",
+    "print(pow(gen, (r - 1) / 276602624281642239937218680557139826668747, r))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4c58ca4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SageMath 9.2",
+   "language": "sage",
+   "name": "sagemath"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/third_party/curve25519/scripts/g1.ipynb
+++ b/third_party/curve25519/scripts/g1.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f890e69f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q = pow(2,255) - 19"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d90a7f0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = 486662\n",
+    "B = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1b2aebc5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "486664\n",
+      "486660\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = (A + 2) * 1\n",
+    "d = (A - 2) * 1\n",
+    "print(a)\n",
+    "print(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "aae2f8bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "u = 9\n",
+    "u"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ea9a4d90",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "14781619447589544791020593568409986887264606134616475288964881837755586237401"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v = mod(u^3 + A * u^2 + u, q).sqrt()\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "95895004",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "38213832894368730265794714087330135568483813637251082400757400312561599933396"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "u * pow(v, -1, q) % q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1134cf74",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "46316835694926478169428394003475163141307993866256225615783033603165251855960"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(u - 1) * pow(u + 1, -1, q) % q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec089e21",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SageMath 9.2",
+   "language": "sage",
+   "name": "sagemath"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/third_party/curve25519/src/constraints/curves.rs
+++ b/third_party/curve25519/src/constraints/curves.rs
@@ -1,0 +1,14 @@
+use ark_r1cs_std::groups::curves::twisted_edwards::{AffineVar, MontgomeryAffineVar};
+
+use crate::{constraints::FqVar, *};
+
+/// A variable that is the R1CS equivalent of `crate::EdwardsAffine`.
+pub type EdwardsVar = AffineVar<EdwardsParameters, FqVar>;
+
+/// A variable that is the R1CS equivalent of `crate::NonZeroMontgomeryAffine`.
+pub type NonZeroMontgomeryVar = MontgomeryAffineVar<EdwardsParameters, FqVar>;
+
+#[test]
+fn test() {
+    ark_curve_constraint_tests::curves::te_test::<EdwardsParameters, EdwardsVar>().unwrap();
+}

--- a/third_party/curve25519/src/constraints/fields.rs
+++ b/third_party/curve25519/src/constraints/fields.rs
@@ -1,0 +1,11 @@
+use ark_r1cs_std::fields::fp::FpVar;
+
+use crate::Fq;
+
+/// A variable that is the R1CS equivalent of `crate::Fq`.
+pub type FqVar = FpVar<Fq>;
+
+#[test]
+fn test() {
+    ark_curve_constraint_tests::fields::field_test::<_, _, FqVar>().unwrap();
+}

--- a/third_party/curve25519/src/constraints/mod.rs
+++ b/third_party/curve25519/src/constraints/mod.rs
@@ -1,0 +1,8 @@
+//! This module implements the R1CS equivalent of `ark_curve25519`.
+//! It requires a curve that embeds curve25519.
+
+mod curves;
+mod fields;
+
+pub use curves::*;
+pub use fields::*;

--- a/third_party/curve25519/src/curves/mod.rs
+++ b/third_party/curve25519/src/curves/mod.rs
@@ -1,0 +1,64 @@
+use crate::{Fq, Fr};
+use ark_ec::{
+    models::CurveConfig,
+    twisted_edwards::{Affine, MontCurveConfig, MontgomeryAffine, Projective, TECurveConfig},
+};
+use ark_ff::MontFp;
+
+#[cfg(test)]
+mod tests;
+
+pub type EdwardsAffine = Affine<EdwardsParameters>;
+pub type EdwardsProjective = Projective<EdwardsParameters>;
+pub type NonZeroMontgomeryAffine = MontgomeryAffine<EdwardsParameters>;
+
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct EdwardsParameters;
+
+impl CurveConfig for EdwardsParameters {
+    type BaseField = Fq;
+    type ScalarField = Fr;
+
+    /// COFACTOR = 8
+    const COFACTOR: &'static [u64] = &[8];
+
+    /// COFACTOR_INV (mod r) =
+    /// 2713877091499598330239944961141122840321418634767465352250731601857045344121
+    const COFACTOR_INV: Fr =
+        MontFp!("2713877091499598330239944961141122840321418634767465352250731601857045344121");
+}
+
+// We want to emphasize that this twisted Edwards curve is not ed25519.
+impl TECurveConfig for EdwardsParameters {
+    /// COEFF_A = 486664
+    const COEFF_A: Fq = MontFp!("486664");
+
+    /// COEFF_D = 486660
+    const COEFF_D: Fq = MontFp!("486660");
+
+    /// Generated randomly
+    const GENERATOR: EdwardsAffine = EdwardsAffine::new_unchecked(GENERATOR_X, GENERATOR_Y);
+
+    type MontCurveConfig = EdwardsParameters;
+}
+
+impl MontCurveConfig for EdwardsParameters {
+    /// COEFF_A = 486662
+    const COEFF_A: Fq = MontFp!("486662");
+
+    /// COEFF_B = 1
+    const COEFF_B: Fq = MontFp!("1");
+
+    type TECurveConfig = EdwardsParameters;
+}
+
+/// GENERATOR_X =
+/// 38213832894368730265794714087330135568483813637251082400757400312561599933396
+const GENERATOR_X: Fq =
+    MontFp!("38213832894368730265794714087330135568483813637251082400757400312561599933396");
+
+/// GENERATOR_Y =
+/// (4/5)
+/// 46316835694926478169428394003475163141307993866256225615783033603165251855960
+const GENERATOR_Y: Fq =
+    MontFp!("46316835694926478169428394003475163141307993866256225615783033603165251855960");

--- a/third_party/curve25519/src/curves/tests.rs
+++ b/third_party/curve25519/src/curves/tests.rs
@@ -1,0 +1,4 @@
+use crate::*;
+use ark_algebra_test_templates::*;
+
+test_group!(te; EdwardsProjective; te);

--- a/third_party/curve25519/src/fields/fq.rs
+++ b/third_party/curve25519/src/fields/fq.rs
@@ -1,0 +1,7 @@
+use ark_ff::fields::{Fp256, MontBackend, MontConfig};
+
+#[derive(MontConfig)]
+#[modulus = "57896044618658097711785492504343953926634992332820282019728792003956564819949"]
+#[generator = "2"]
+pub struct FqConfig;
+pub type Fq = Fp256<MontBackend<FqConfig, 4>>;

--- a/third_party/curve25519/src/fields/fr.rs
+++ b/third_party/curve25519/src/fields/fr.rs
@@ -1,0 +1,7 @@
+use ark_ff::fields::{Fp256, MontBackend, MontConfig};
+
+#[derive(MontConfig)]
+#[modulus = "7237005577332262213973186563042994240857116359379907606001950938285454250989"]
+#[generator = "2"]
+pub struct FrConfig;
+pub type Fr = Fp256<MontBackend<FrConfig, 4>>;

--- a/third_party/curve25519/src/fields/mod.rs
+++ b/third_party/curve25519/src/fields/mod.rs
@@ -1,0 +1,8 @@
+mod fq;
+mod fr;
+
+pub use fq::*;
+pub use fr::*;
+
+#[cfg(test)]
+mod tests;

--- a/third_party/curve25519/src/fields/tests.rs
+++ b/third_party/curve25519/src/fields/tests.rs
@@ -1,0 +1,5 @@
+use crate::{Fq, Fr};
+use ark_algebra_test_templates::*;
+
+test_field!(fr; Fr; mont_prime_field);
+test_field!(fq; Fq; mont_prime_field);

--- a/third_party/curve25519/src/lib.rs
+++ b/third_party/curve25519/src/lib.rs
@@ -1,0 +1,28 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(
+    warnings,
+    unused,
+    future_incompatible,
+    nonstandard_style,
+    rust_2018_idioms
+)]
+#![forbid(unsafe_code)]
+
+//! This library implements the curve25519 Montgomery curve.
+//!
+//! Curve information:
+//! * Base field: q =
+//!   57896044618658097711785492504343953926634992332820282019728792003956564819949
+//! * Scalar field: r =
+//!   7237005577332262213973186563042994240857116359379907606001950938285454250989
+//! * Curve equation: B * y^2 = x^3 + A * x^2 + x, where
+//!    * A = 486662
+//!    * B = 1
+
+#[cfg(feature = "r1cs")]
+pub mod constraints;
+mod curves;
+mod fields;
+
+pub use curves::*;
+pub use fields::*;


### PR DESCRIPTION
## Motivation

The performance of R1CS proof generation is affected by the slow circuit evaluation, this pull request improved the CirC evaluation speed through several changes
- preprocessed the precompute to avoid dfs and hashmap lookup during evaluation
- change the implementation of Array from BTreeMap to im::OrdMap, which makes the cost of updating an array from O(n) to O(logn)
- Extend opt to PreCompute, `ConstantFold`, `Obliv` and `Tuple` is implemented at this point to convert Oblivious array lookup to variable in PreCompute, this reduce the eval cost a lot
- several Serialization traits are implemented 
- ark-ff Curve25519 is integrated to support Spartan, but it seems Spartan integration exists in another PR, so I remove my Spartan integration

Moreover, after preprocessing, the Prover doesn't need to hold `TermData` to evaluate, but the new `NumTerm` instead, which can potentially reduce the cost of serializing the prover data from O(n^2) to O(n), more code is needed to make this work

## Benchmark
run `cargo run --release --example run_zok` to compare the time taken to evaluate a `shaRound` before and after the optimization

The time dropped from 115ms to 23ms, though 13ms of the 23ms is spent on building a hashmap for bellman, which could be avoided

## TODO

- [ ] test cases