### PR TITLE
Better serde for Computation, PreComp, R1cs

### DIFF
--- a/examples/ZoKrates/pf/mm3.zok
+++ b/examples/ZoKrates/pf/mm3.zok
@@ -1,0 +1,12 @@
+def main(private field[3][3] A, private field[3][3] B) -> field[3][3]:
+    field [3][3] AB = [[0; 3]; 3]
+    for field i in 0..3 do
+        for field j in 0..3 do
+            for field k in 0..3 do
+                AB[i][j] = AB[i][j] + A[i][k] * B[k][j]
+            endfor
+        endfor
+    endfor
+    return AB
+
+

--- a/examples/ZoKrates/pf/mm4.zok
+++ b/examples/ZoKrates/pf/mm4.zok
@@ -1,0 +1,12 @@
+def main(private field[4][4] A, private field[4][4] B) -> field[4][4]:
+    field [4][4] AB = [[0; 4]; 4]
+    for field i in 0..4 do
+        for field j in 0..4 do
+            for field k in 0..4 do
+                AB[i][j] = AB[i][j] + A[i][k] * B[k][j]
+            endfor
+        endfor
+    endfor
+    return AB
+
+

--- a/examples/ZoKrates/pf/mm5.zok
+++ b/examples/ZoKrates/pf/mm5.zok
@@ -1,0 +1,12 @@
+def main(private field[5][5] A, private field[5][5] B) -> field[5][5]:
+    field [5][5] AB = [[0; 5]; 5]
+    for field i in 0..5 do
+        for field j in 0..5 do
+            for field k in 0..5 do
+                AB[i][j] = AB[i][j] + A[i][k] * B[k][j]
+            endfor
+        endfor
+    endfor
+    return AB
+
+

--- a/src/ir/opt/mem/lin.rs
+++ b/src/ir/opt/mem/lin.rs
@@ -116,6 +116,7 @@ mod test {
             b"
             (computation
                 (metadata () ((a (bv 4)) (b (bv 4)) (c (bv 4))) ())
+                (precompute () () (#t ))
                 (let
                     (
                         (c_array (#a (bv 4) #x0 4 ()))
@@ -138,6 +139,7 @@ mod test {
             b"
             (computation
                 (metadata () ((a (mod 5)) (b (mod 5)) (c (mod 5))) ())
+                (precompute () () (#t ))
                 (let
                     (
                         (c_array (#a (mod 5) #f1m5 4 ()))
@@ -160,6 +162,7 @@ mod test {
             b"
             (computation
                 (metadata () ((a (bv 4)) (b (bv 4)) (c (bv 4))) ())
+                (precompute () () (#t ))
                 (let
                     (
                         (c_array (#a (bv 4) #x0 4 ()))
@@ -182,6 +185,7 @@ mod test {
             b"
             (computation
                 (metadata () ((a (mod 5)) (b (mod 5)) (c (mod 5))) ())
+                (precompute () () (#t ))
                 (let
                     (
                         (c_array (#a (mod 5) #f1m5 4 ()))

--- a/src/ir/opt/mem/ram.rs
+++ b/src/ir/opt/mem/ram.rs
@@ -331,6 +331,7 @@ mod test {
             b"
             (computation
                 (metadata () () ())
+                (precompute () () (#t ))
                 (let
                     (
                         (c_array (#a (bv 4) #x0 4 ()))
@@ -355,6 +356,7 @@ mod test {
             b"
             (computation
                 (metadata () () ())
+                (precompute () () (#t ))
                 (let
                     (
                         (c_array (#a (bv 4) #b000 4 ()))
@@ -392,6 +394,7 @@ mod test {
             b"
             (computation
                 (metadata () ((a bool)) ())
+                (precompute () () (#t ))
                 (let
                     (
                         (c_array (#a (bv 4) #b000 4 ()))
@@ -430,6 +433,7 @@ mod test {
             b"
             (computation
                 (metadata () ((a bool)) ())
+                (precompute () () (#t ))
                 (let
                     (
                         (c_array (#a (bv 4) #b000 4 ()))
@@ -469,6 +473,7 @@ mod test {
             b"
             (computation
                 (metadata () ((a bool)) ())
+                (precompute () () (#t ))
                 (let
                     (
                         ; connected component 0: simple store chain

--- a/src/ir/term/mod.rs
+++ b/src/ir/term/mod.rs
@@ -1982,7 +1982,7 @@ impl Display for ComputationMetadata {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 /// An IR computation.
 pub struct Computation {
     /// The outputs of the computation.
@@ -2092,6 +2092,42 @@ impl Computation {
         // drop the top-level tuple term.
         terms.pop();
         terms.into_iter()
+    }
+}
+
+impl Serialize for Computation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes = text::serialize_computation(self);
+        serializer.serialize_str(&bytes)
+    }
+}
+
+struct ComputationDeserVisitor;
+
+impl<'de> Visitor<'de> for ComputationDeserVisitor {
+    type Value = Computation;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a string (that textually defines a term)")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: std::error::Error,
+    {
+        Ok(text::parse_computation(v.as_bytes()).clone())
+    }
+}
+
+impl<'de> Deserialize<'de> for Computation {
+    fn deserialize<D>(deserializer: D) -> Result<Computation, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(ComputationDeserVisitor)
     }
 }
 

--- a/src/ir/term/mod.rs
+++ b/src/ir/term/mod.rs
@@ -2118,7 +2118,7 @@ impl<'de> Visitor<'de> for ComputationDeserVisitor {
     where
         E: std::error::Error,
     {
-        Ok(text::parse_computation(v.as_bytes()).clone())
+        Ok(text::parse_computation(v.as_bytes()))
     }
 }
 

--- a/src/ir/term/precomp.rs
+++ b/src/ir/term/precomp.rs
@@ -147,7 +147,7 @@ impl<'de> Visitor<'de> for PreCompDeserVisitor {
     where
         E: std::error::Error,
     {
-        Ok(text::parse_precompute(v.as_bytes()).clone())
+        Ok(text::parse_precompute(v.as_bytes()))
     }
 }
 


### PR DESCRIPTION
The previous implementation for all 3 structures would separately serialize each term in a precomputation. This was very bad, because precomputations can be quite large, and the different terms typically share large numbers of sub-terms. This can be quadratic blowup.

Change list:
* add input/output type metadata to PreComp (this makes the type of variables in a PreComp clear)
* add textual serialization and parsing for PreComp (and include this in Computation)
* add serde implementations for Computation and PreCop based on the text formats.
* modify the R1cs serde derive so that the `Vec<Term>` is tuplized before serde

This reduces our prover-key size for `verifyEddsa.zok` from wildly large (>450GB) to 171MB.

Collin and Anna first observed this bug. Collin's PR #118 works around it (among other improvements).