### PR TITLE
Better serde impl for bellman keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "rsmt2",
  "rug",
  "serde",
+ "serde_bytes",
  "serde_json",
  "spartan",
  "structopt",
@@ -1324,6 +1325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ group = "0.12"
 lp-solvers = { version = "0.0.4", optional = true }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
+serde_bytes = "0.11"
 bincode = "1.3.3"
 lang-c = { version = "0.10.1", optional = true}
 logos = "0.12"

--- a/src/target/r1cs/bellman.rs
+++ b/src/target/r1cs/bellman.rs
@@ -180,14 +180,14 @@ mod serde_pk {
     ) -> Result<S::Ok, S::Error> {
         let mut bs: Vec<u8> = Vec::new();
         p.write(&mut bs).unwrap();
-        ser.serialize_bytes(&bs)
+        serde_bytes::ByteBuf::from(bs).serialize(ser)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>, E: Engine>(
         de: D,
     ) -> Result<Parameters<E>, D::Error> {
-        let bs: &'de [u8] = Deserialize::deserialize(de)?;
-        Ok(Parameters::read(bs, false).unwrap())
+        let bs: serde_bytes::ByteBuf = Deserialize::deserialize(de)?;
+        Ok(Parameters::read(&**bs, false).unwrap())
     }
 }
 
@@ -208,14 +208,14 @@ mod serde_vk {
     ) -> Result<S::Ok, S::Error> {
         let mut bs: Vec<u8> = Vec::new();
         p.write(&mut bs).unwrap();
-        ser.serialize_bytes(&bs)
+        serde_bytes::ByteBuf::from(bs).serialize(ser)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>, E: Engine>(
         de: D,
     ) -> Result<VerifyingKey<E>, D::Error> {
-        let bs: &'de [u8] = Deserialize::deserialize(de)?;
-        Ok(VerifyingKey::read(bs).unwrap())
+        let bs: serde_bytes::ByteBuf = Deserialize::deserialize(de)?;
+        Ok(VerifyingKey::read(&**bs).unwrap())
     }
 }
 

--- a/src/target/r1cs/bellman.rs
+++ b/src/target/r1cs/bellman.rs
@@ -163,6 +163,62 @@ pub fn parse_instance<P: AsRef<Path>, F: PrimeField>(path: P) -> Vec<F> {
         .collect()
 }
 
+mod serde_pk {
+    use bellman::groth16::Parameters;
+    use pairing::Engine;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize)]
+    pub struct SerPk<'a, E: Engine>(#[serde(with = "self")] pub &'a Parameters<E>);
+
+    #[derive(Deserialize)]
+    pub struct DePk<E: Engine>(#[serde(with = "self")] pub Parameters<E>);
+
+    pub fn serialize<S: Serializer, E: Engine>(
+        p: &Parameters<E>,
+        ser: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut bs: Vec<u8> = Vec::new();
+        p.write(&mut bs).unwrap();
+        ser.serialize_bytes(&bs)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>, E: Engine>(
+        de: D,
+    ) -> Result<Parameters<E>, D::Error> {
+        let bs: &'de [u8] = Deserialize::deserialize(de)?;
+        Ok(Parameters::read(bs, false).unwrap())
+    }
+}
+
+mod serde_vk {
+    use bellman::groth16::VerifyingKey;
+    use pairing::Engine;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize)]
+    pub struct SerVk<'a, E: Engine>(#[serde(with = "self")] pub &'a VerifyingKey<E>);
+
+    #[derive(Deserialize)]
+    pub struct DeVk<E: Engine>(#[serde(with = "self")] pub VerifyingKey<E>);
+
+    pub fn serialize<S: Serializer, E: Engine>(
+        p: &VerifyingKey<E>,
+        ser: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut bs: Vec<u8> = Vec::new();
+        p.write(&mut bs).unwrap();
+        ser.serialize_bytes(&bs)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>, E: Engine>(
+        de: D,
+    ) -> Result<VerifyingKey<E>, D::Error> {
+        let bs: &'de [u8] = Deserialize::deserialize(de)?;
+        Ok(VerifyingKey::read(bs).unwrap())
+    }
+}
+
 /// Given
 /// * a proving-key path,
 /// * a verifying-key path,
@@ -191,10 +247,8 @@ fn write_prover_key_and_data<P: AsRef<Path>, E: Engine>(
     params: &Parameters<E>,
     data: &ProverData,
 ) -> io::Result<()> {
-    let mut pk: Vec<u8> = Vec::new();
-    params.write(&mut pk)?;
     let mut file = File::create(path)?;
-    serialize_into(&mut file, &(&pk, &data)).unwrap();
+    serialize_into(&mut file, &(serde_pk::SerPk(params), &data)).unwrap();
     Ok(())
 }
 
@@ -202,8 +256,7 @@ fn read_prover_key_and_data<P: AsRef<Path>, E: Engine>(
     path: P,
 ) -> io::Result<(Parameters<E>, ProverData)> {
     let mut file = File::open(path)?;
-    let (pk_bytes, data): (Vec<u8>, ProverData) = deserialize_from(&mut file).unwrap();
-    let pk: Parameters<E> = Parameters::read(pk_bytes.as_slice(), false)?;
+    let (serde_pk::DePk(pk), data): (_, ProverData) = deserialize_from(&mut file).unwrap();
     Ok((pk, data))
 }
 
@@ -212,10 +265,8 @@ fn write_verifier_key_and_data<P: AsRef<Path>, E: Engine>(
     key: &VerifyingKey<E>,
     data: &VerifierData,
 ) -> io::Result<()> {
-    let mut vk: Vec<u8> = Vec::new();
-    key.write(&mut vk)?;
     let mut file = File::create(path)?;
-    serialize_into(&mut file, &(&vk, &data)).unwrap();
+    serialize_into(&mut file, &(serde_vk::SerVk(key), &data)).unwrap();
     Ok(())
 }
 
@@ -223,8 +274,7 @@ fn read_verifier_key_and_data<P: AsRef<Path>, E: Engine>(
     path: P,
 ) -> io::Result<(VerifyingKey<E>, VerifierData)> {
     let mut file = File::open(path)?;
-    let (vk_bytes, data): (Vec<u8>, VerifierData) = deserialize_from(&mut file).unwrap();
-    let vk: VerifyingKey<E> = VerifyingKey::read(vk_bytes.as_slice())?;
+    let (serde_vk::DeVk(vk), data): (_, VerifierData) = deserialize_from(&mut file).unwrap();
     Ok((vk, data))
 }
 


### PR DESCRIPTION
Bellman keys (pk and vk) expose non-trait read and write functions for interacting with `io::{Read,Write}`. They don't expose serde impls. We need to serde them.

Previously, we used the io interface to convert from/to a `Vec<u8>`, whose serde impl we used.

This was a bad idea b/c the serde impl for `Vec<u8>` is bad. It gets stuck with the generic serde impl for `Vec`, rather than using `(de)serialize_bytes`.

Now, we have serde-impl'd wrapper types for pk and vk that do the right thing.

By my measurements, this decreases the cost of serializing a circ pk by about 84%.