### PR TITLE
Bugfixes: R1CS lowering (includes a soundness bugfix)

### DIFF
--- a/src/target/r1cs/mod.rs
+++ b/src/target/r1cs/mod.rs
@@ -2,6 +2,7 @@
 
 use circ_fields::{FieldT, FieldV};
 use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use lazy_static::lazy_static;
 use log::debug;
 use paste::paste;
 use rug::Integer;
@@ -18,6 +19,34 @@ pub mod opt;
 #[cfg(feature = "r1cs")]
 pub mod spartan;
 pub mod trans;
+
+/// Guarantees for the IR->R1cs transform
+///
+/// Relevant to division by zero (in the field).
+pub enum Relaxation {
+    /// May introduce incompleteness
+    Incomplete,
+    /// May introduce non-determinism
+    NonDet,
+    /// Deterministic
+    Det,
+}
+
+lazy_static! {
+    static ref RELAXATION: Relaxation = {
+        match std::env::var("CIRC_RELAXATION")
+            .map(|s| s.to_lowercase())
+            .as_ref()
+            .map(|s| s.as_str())
+        {
+            Ok("incomplete") => Relaxation::Incomplete,
+            Ok("nondet") => Relaxation::NonDet,
+            Ok("det") => Relaxation::Det,
+            Ok(s) => panic!("Invalid CIRC_RELAXATION {}. Should be: incomplete, nondet or det", s),
+            Err(_) => Relaxation::Det,
+        }
+    };
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// A Rank 1 Constraint System.

--- a/src/target/r1cs/mod.rs
+++ b/src/target/r1cs/mod.rs
@@ -46,7 +46,7 @@ lazy_static! {
                 "Invalid CIRC_RELAXATION {}. Should be: incomplete, nondet or det",
                 s
             ),
-            Err(_) => Relaxation::Det,
+            Err(_) => Relaxation::Incomplete,
         }
     };
 }

--- a/src/target/r1cs/mod.rs
+++ b/src/target/r1cs/mod.rs
@@ -42,7 +42,10 @@ lazy_static! {
             Ok("incomplete") => Relaxation::Incomplete,
             Ok("nondet") => Relaxation::NonDet,
             Ok("det") => Relaxation::Det,
-            Ok(s) => panic!("Invalid CIRC_RELAXATION {}. Should be: incomplete, nondet or det", s),
+            Ok(s) => panic!(
+                "Invalid CIRC_RELAXATION {}. Should be: incomplete, nondet or det",
+                s
+            ),
             Err(_) => Relaxation::Det,
         }
     };

--- a/src/target/r1cs/trans.rs
+++ b/src/target/r1cs/trans.rs
@@ -164,19 +164,6 @@ impl ToR1cs {
         bits
     }
 
-    /// Given wire `x`, returns whether `x` fits in `n` `signed` bits.
-    fn fits_in_bits<D: Display + ?Sized>(
-        &mut self,
-        d: &D,
-        x: &TermLc,
-        n: usize,
-        signed: bool,
-    ) -> TermLc {
-        let bits = self.decomp(d, x, n);
-        let sum = self.debitify(bits.iter().cloned(), signed);
-        self.are_equal(sum, x)
-    }
-
     /// Given a sequence of `bits`, returns a wire which represents their sum,
     /// `\sum_{i>0} b_i2^i`.
     ///
@@ -455,10 +442,13 @@ impl ToR1cs {
         }
     }
 
-    /// Returns whether `a - b` fits in `size` non-negative bits.
-    /// i.e. is in `{0, 1, ..., 2^n-1}`.
-    fn bv_ge(&mut self, a: TermLc, b: &TermLc, size: usize) -> TermLc {
-        self.fits_in_bits("ge", &(a - b), size, false)
+    /// Given a and b such that -2^n < a - b < 2^n, returns whether a >= b (or a > b if `strict` is
+    /// set).
+    fn bv_greater(&mut self, a: TermLc, b: TermLc, n: usize, strict: bool) -> TermLc {
+        let tweak = if strict { -1 } else { 0 };
+        let shift = self.r1cs.modulus.new_v(Integer::from(1) << n);
+        let sum = a - &b + &shift + tweak;
+        self.decomp("cmp", &sum, n + 1).pop().unwrap()
     }
 
     /// Returns whether `a` is (`strict`ly) (`signed`ly) greater than `b`.
@@ -474,8 +464,7 @@ impl ToR1cs {
         } else {
             self.get_bv_uint(b)
         };
-        // Use the fact: a > b <=> a - 1 >= b
-        self.bv_ge(if strict { a - 1 } else { a }, &b, w)
+        self.bv_greater(a, b, w, strict)
     }
 
     /// Shift `x` left by `2^y`, if bit-valued `c` is true.
@@ -499,17 +488,40 @@ impl ToR1cs {
 
     /// Shift `x` left by `y`, filling the blank spots with bit-valued `ext_bit`.
     /// Returns a bit sequence.
+    ///
+    /// If `c` is true, returns bit sequence which is just a copy of `ext_bit`.
     fn shift_bv_bits(
         &mut self,
         x: TermLc,
         y: Vec<TermLc>,
         ext_bit: Option<TermLc>,
-        n: usize,
+        x_w: usize,
+        c: TermLc,
     ) -> Vec<TermLc> {
+        let y_w = y.len();
+        let mask: TermLc = match ext_bit.as_ref() {
+            Some(e) => e.clone() * &self.r1cs.modulus.new_v((1 << x_w) - 1),
+            None => self.zero.clone(),
+        };
         let s = self.shift_bv(x, y, ext_bit);
-        let mut bits = self.bitify("shift", &s, 2 * n - 1, false);
-        bits.truncate(n);
+        let masked_s = self.ite(c, mask, &s);
+        let mut bits = self.bitify("shift", &masked_s, (1 << y_w) + x_w - 1, false);
+        bits.truncate(x_w);
         bits
+    }
+
+    /// Given a shift amount expressed as a bit-sequence, splits that shift into low bits and high
+    /// bits. The number of low bits, `b`, is the minimum amount such that `data_w-1` is representable
+    /// in `b` bits. The rest of the bits (the high ones) are or'd together into a single bit that is
+    /// returned.
+    fn split_shift_amt(
+        &mut self,
+        data_w: usize,
+        mut shift_amt: Vec<TermLc>,
+    ) -> (TermLc, Vec<TermLc>) {
+        let b = bitsize(data_w - 1);
+        let some_high_bit = self.nary_or(shift_amt.drain(b..));
+        (some_high_bit, shift_amt)
     }
 
     fn embed_bv(&mut self, bv: Term) {
@@ -659,7 +671,6 @@ impl ToR1cs {
                                 self.set_bv_bits(bv, bits);
                             }
                             BvBinOp::Udiv | BvBinOp::Urem => {
-                                let is_zero = self.is_zero(b.clone());
                                 let a_bv_term = term![Op::PfToBv(n); a.0.clone()];
                                 let b_bv_term = term![Op::PfToBv(n); b.0.clone()];
                                 let q_term = term![Op::UbvToPf(self.field.clone()); term![BV_UDIV; a_bv_term.clone(), b_bv_term.clone()]];
@@ -669,11 +680,16 @@ impl ToR1cs {
                                 let qb = self.bitify("div_q", &q, n, false);
                                 let rb = self.bitify("div_r", &r, n, false);
                                 self.r1cs.constraint(q.1.clone(), b.1.clone(), (a - &r).1);
-                                let is_gt = self.bv_ge(b - 1, &r, n);
-                                let is_not_ge = self.bool_not(&is_gt);
-                                let is_not_zero = self.bool_not(&is_zero);
-                                self.r1cs
-                                    .constraint(is_not_ge.1, is_not_zero.1, self.r1cs.zero());
+                                // b == 0 -> q == M   //  b != 0 or q == M
+                                // b != 0 -> r < b    //  b == 0 or r < b
+                                // so, since we don't care about b == 0,
+                                // q == M or r < b
+                                // not(q != M and r >= b)
+                                let r_ge_b = self.bv_greater(r, b, n, false);
+                                let max = self.r1cs.modulus.new_v((Integer::from(1) << n) - 1);
+                                let q_eq_max = self.is_zero(q - &max);
+                                let q_ne_max = self.bool_not(&q_eq_max);
+                                self.r1cs.constraint(r_ge_b.1, q_ne_max.1, self.r1cs.zero());
                                 let bits = match o {
                                     BvBinOp::Udiv => qb,
                                     BvBinOp::Urem => rb,
@@ -683,15 +699,10 @@ impl ToR1cs {
                             }
                             // Shift cases
                             _ => {
-                                let r = b;
-                                let b = bitsize(n - 1);
-                                assert!(1 << b == n);
-                                let mut rb = self.get_bv_bits(&bv.cs[1]);
-                                rb.truncate(b);
-                                let sum = self.debitify(rb.clone().into_iter(), false);
-                                self.assert_zero(sum - &r);
+                                let rb = self.get_bv_bits(&bv.cs[1]);
+                                let (high, low) = self.split_shift_amt(n, rb);
                                 let bits = match o {
-                                    BvBinOp::Shl => self.shift_bv_bits(a, rb, None, n),
+                                    BvBinOp::Shl => self.shift_bv_bits(a, low, None, n, high),
                                     BvBinOp::Lshr | BvBinOp::Ashr => {
                                         let mut lb = self.get_bv_bits(&bv.cs[0]);
                                         lb.reverse();
@@ -700,7 +711,7 @@ impl ToR1cs {
                                             _ => None,
                                         };
                                         let l = self.debitify(lb.into_iter(), false);
-                                        let mut bits = self.shift_bv_bits(l, rb, ext_bit, n);
+                                        let mut bits = self.shift_bv_bits(l, low, ext_bit, n, high);
                                         bits.reverse();
                                         bits
                                     }
@@ -859,13 +870,47 @@ impl ToR1cs {
                 }
                 Op::UbvToPf(_) => self.get_bv_uint(&c.cs[0]),
                 Op::PfUnOp(PfUnOp::Neg) => -self.get_pf(&c.cs[0]).clone(),
-                Op::PfUnOp(PfUnOp::Recip) => {
-                    let x = self.get_pf(&c.cs[0]).clone();
-                    let inv_x = self.fresh_var("recip", term![PF_RECIP; x.0.clone()], false);
-                    self.r1cs
-                        .constraint(x.1, inv_x.1.clone(), self.r1cs.zero() + 1);
-                    inv_x
-                }
+                Op::PfUnOp(PfUnOp::Recip) => match *super::RELAXATION {
+                    Relaxation::Incomplete => {
+                        // ix = 1
+                        let x = self.get_pf(&c.cs[0]).clone();
+                        let inv_x = self.fresh_var("recip", term![PF_RECIP; x.0.clone()], false);
+                        self.r1cs
+                            .constraint(x.1, inv_x.1.clone(), self.r1cs.zero() + 1);
+                        inv_x
+                    }
+                    Relaxation::NonDet => {
+                        // ixx = x
+                        let x = self.get_pf(&c.cs[0]).clone();
+                        let x2 = self.mul(x.clone(), x.clone());
+                        let inv_x = self.fresh_var("recip", term![PF_RECIP; x.0.clone()], false);
+                        self.r1cs.constraint(x2.1, inv_x.1.clone(), x.1);
+                        inv_x
+                    }
+                    Relaxation::Det => {
+                        // ix = 1 - z
+                        // zx = 0
+                        // zi = 0
+                        let x = self.get_pf(&c.cs[0]).clone();
+                        let eqz = term![Op::Eq; x.0.clone(), self.zero.0.clone()];
+                        let i = self.fresh_var(
+                            "is_zero_inv",
+                            term![Op::Ite; eqz.clone(), self.zero.0.clone(), term![PF_RECIP; x.0.clone()]],
+                            false,
+                        );
+                        let z = self.fresh_var(
+                            "is_zero",
+                            term![Op::Ite; eqz, self.one.0.clone(), self.zero.0.clone()],
+                            false,
+                        );
+                        self.r1cs
+                            .constraint(i.1.clone(), x.1.clone(), -z.1.clone() + 1);
+                        self.r1cs.constraint(z.1.clone(), x.1, self.r1cs.zero());
+                        self.r1cs
+                            .constraint(z.1.clone(), i.1.clone(), self.r1cs.zero());
+                        i
+                    }
+                },
                 _ => panic!("Non-field in embed_pf: {}", c),
             };
             self.cache.insert(c.clone(), EmbeddedTerm::Field(lc));

--- a/src/target/r1cs/trans.rs
+++ b/src/target/r1cs/trans.rs
@@ -906,8 +906,7 @@ impl ToR1cs {
                         self.r1cs
                             .constraint(i.1.clone(), x.1.clone(), -z.1.clone() + 1);
                         self.r1cs.constraint(z.1.clone(), x.1, self.r1cs.zero());
-                        self.r1cs
-                            .constraint(z.1, i.1.clone(), self.r1cs.zero());
+                        self.r1cs.constraint(z.1, i.1.clone(), self.r1cs.zero());
                         i
                     }
                 },

--- a/src/target/r1cs/trans.rs
+++ b/src/target/r1cs/trans.rs
@@ -907,7 +907,7 @@ impl ToR1cs {
                             .constraint(i.1.clone(), x.1.clone(), -z.1.clone() + 1);
                         self.r1cs.constraint(z.1.clone(), x.1, self.r1cs.zero());
                         self.r1cs
-                            .constraint(z.1.clone(), i.1.clone(), self.r1cs.zero());
+                            .constraint(z.1, i.1.clone(), self.r1cs.zero());
                         i
                     }
                 },


### PR DESCRIPTION
Fixes 4 bugs in R1CS lowering:
* division-by-zero in finite fields: previously, this always caused incompleteness. Now, the behavior depends on the CIRC_RELAXATION envvar:
  * CIRC_RELAXATION=incomplete: divide-by-0 causes incompletenes
  * CIRC_RELAXATION=nondet: divide-by-0 allows the output to take any value
  * CIRC_RELAXATION=det: divide-by-0 forces the output to 0
* bit-vector overshift: previously, this cause incompleteness. Now, we follow the semantics of SMT-LIB (the result saturates).
* bit-vector udiv-by-zero: previously, the output value was an unconstrained bit-vector. Now, it is MAX (following SMT-LIB).
* bit-vector comparisons: previously, the prover could lie, claiming that x < y when actually x >= y. All bit-vector comparisons are affected, including those in udiv and urem.
  * soundness bug!