### PR TITLE
Clippy: uninlined_format_args

### DIFF
--- a/examples/circ.rs
+++ b/examples/circ.rs
@@ -149,7 +149,7 @@ fn determine_language(l: &Language, input_path: &Path) -> DeterminedLanguage {
             } else if p.ends_with(".c") || p.ends_with(".cpp") || p.ends_with(".cc") {
                 DeterminedLanguage::C
             } else {
-                println!("Could not deduce the input language from path '{}', please set the language manually", p);
+                println!("Could not deduce the input language from path '{p}', please set the language manually");
                 std::process::exit(2)
             }
         }
@@ -165,7 +165,7 @@ fn main() {
     let options = Options::parse();
     circ::cfg::set(&options.circ);
     let path_buf = options.path.clone();
-    println!("{:?}", options);
+    println!("{options:?}");
     let mode = match options.backend {
         Backend::R1cs { .. } => match options.frontend.value_threshold {
             Some(t) => Mode::ProofOfHighValue(t),
@@ -321,8 +321,8 @@ fn main() {
                 DeterminedLanguage::Zsharp => "zok".to_string(),
                 _ => panic!("Language isn't supported by MPC backend: {:#?}", language),
             };
-            println!("Cost model: {}", cost_model);
-            println!("Selection scheme: {}", selection_scheme);
+            println!("Cost model: {cost_model}");
+            println!("Selection scheme: {selection_scheme}");
             to_aby(cs, &path_buf, &lang_str, &cost_model, &selection_scheme);
         }
         #[cfg(not(feature = "aby"))]
@@ -368,7 +368,7 @@ fn main() {
                     Some(m) => {
                         println!("Not primitive recursive!");
                         for (var, val) in m {
-                            println!("{} -> {}", var, val);
+                            println!("{var} -> {val}");
                         }
                         std::process::exit(1)
                     }

--- a/examples/zxc.rs
+++ b/examples/zxc.rs
@@ -84,7 +84,7 @@ fn main() {
         .init();
     let options = Options::parse();
     circ::cfg::set(&options.circ);
-    println!("{:?}", options);
+    println!("{options:?}");
 
     let cs = {
         let inputs = zsharp::Inputs {

--- a/src/circify/mod.rs
+++ b/src/circify/mod.rs
@@ -62,8 +62,8 @@ pub type Result<T> = std::result::Result<T, CircError>;
 impl<T: Display> Display for Val<T> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Val::Term(t) => write!(f, "{}", t),
-            Val::Ref(l) => write!(f, "&{}", l),
+            Val::Term(t) => write!(f, "{t}"),
+            Val::Ref(l) => write!(f, "&{l}"),
         }
     }
 }
@@ -160,9 +160,7 @@ impl<Ty: Display> LexScope<Ty> {
     fn declare(&mut self, name: VarName, ty: Ty) -> Result<&SsaName> {
         let p = &self.prefix;
         match self.entries.entry(name.clone()) {
-            Entry::Vacant(v) => Ok(&v
-                .insert(LexEntry::new(format!("{}_{}", p, name), ty))
-                .ssa_name),
+            Entry::Vacant(v) => Ok(&v.insert(LexEntry::new(format!("{p}_{name}"), ty)).ssa_name),
             Entry::Occupied(o) => Err(CircError::Rebind(name, format!("{}", o.get().ty))),
         }
     }
@@ -595,8 +593,8 @@ impl<E: Embeddable> Circify<E> {
                 let new_ty = new.type_();
                 assert_eq!(
                     ty, new_ty,
-                    "Term {} has type {} but was assigned to {} of type {}",
-                    new, new_ty, loc, ty
+                    "{}",
+                    "Term {new} has type {new_ty} but was assigned to {loc} of type {ty}",
                 );
                 // get condition under which assignment happens
                 let guard = self.condition.clone();
@@ -617,9 +615,9 @@ impl<E: Embeddable> Circify<E> {
                 Ok(v)
             }
             (_, v) => Err(CircError::MisTypedAssign(
-                format!("{}", v),
-                format!("{}", loc),
-                format!("{}", old_val),
+                format!("{v}"),
+                format!("{loc}"),
+                format!("{old_val}"),
             )),
         }
     }
@@ -879,8 +877,8 @@ mod test {
         impl Display for T {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
                 match self {
-                    T::Base(t) => write!(f, "{}", t),
-                    T::Pair(a, b) => write!(f, "({}, {})", a, b),
+                    T::Base(t) => write!(f, "{t}"),
+                    T::Pair(a, b) => write!(f, "({a}, {b})"),
                 }
             }
         }
@@ -895,7 +893,7 @@ mod test {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
                 match self {
                     Ty::Bool => write!(f, "bool"),
-                    Ty::Pair(a, b) => write!(f, "({}, {})", a, b),
+                    Ty::Pair(a, b) => write!(f, "({a}, {b})"),
                 }
             }
         }
@@ -968,14 +966,14 @@ mod test {
                             Box::new(self.declare_input(
                                 ctx,
                                 a,
-                                format!("{}.0", name),
+                                format!("{name}.0"),
                                 visibility,
                                 p_1,
                             )),
                             Box::new(self.declare_input(
                                 ctx,
                                 b,
-                                format!("{}.1", name),
+                                format!("{name}.1"),
                                 visibility,
                                 p_2,
                             )),

--- a/src/front/c/mod.rs
+++ b/src/front/c/mod.rs
@@ -131,7 +131,7 @@ impl CGen {
 
     /// Unwrap a result of an error and abort
     fn err<E: Display>(&self, e: E) -> ! {
-        println!("Error: {}", e);
+        println!("Error: {e}");
         std::process::exit(1)
     }
 
@@ -366,10 +366,10 @@ impl CGen {
             if let Some((_, term_)) = fs.search(field) {
                 Ok(term_.clone())
             } else {
-                Err(format!("No field '{}'", field))
+                Err(format!("No field '{field}'"))
             }
         } else {
-            Err(format!("{} is not a struct", struct_))
+            Err(format!("{struct_} is not a struct"))
         }
     }
 
@@ -381,10 +381,10 @@ impl CGen {
                 let res = cterm(CTermData::CStruct(struct_ty.clone(), new_fs.clone()));
                 Ok(res)
             } else {
-                Err(format!("No field '{}'", field))
+                Err(format!("No field '{field}'"))
             }
         } else {
-            Err(format!("{} is not a struct", struct_))
+            Err(format!("{struct_} is not a struct"))
         }
     }
 
@@ -409,7 +409,7 @@ impl CGen {
                     _ => unimplemented!(),
                 }))
             }
-            (a, b) => Err(format!("[Array Select] cannot index {} by {}", a, b)),
+            (a, b) => Err(format!("[Array Select] cannot index {a} by {b}")),
         }
     }
 
@@ -447,7 +447,7 @@ impl CGen {
                     Ok(val.clone())
                 }
             }
-            (a, b) => Err(format!("[Array Store] cannot index {} by {}", a, b)),
+            (a, b) => Err(format!("[Array Store] cannot index {a} by {b}")),
         }
     }
 
@@ -530,7 +530,7 @@ impl CGen {
             CLoc::Var(l) => {
                 let org_type = self
                     .circ_get_value(l.clone())
-                    .map_err(|e| format!("{}", e))?
+                    .map_err(|e| format!("{e}"))?
                     .unwrap_term()
                     .term
                     .type_();
@@ -542,26 +542,26 @@ impl CGen {
                 };
                 Ok(self
                     .circ_assign(l, Val::Term(new_val))
-                    .map_err(|e| format!("{}", e))?
+                    .map_err(|e| format!("{e}"))?
                     .unwrap_term())
             }
             CLoc::Idx(l, idx) => {
                 let old_inner: CTerm = match *l {
                     CLoc::Var(inner_loc) => self
                         .circ_get_value(inner_loc)
-                        .map_err(|e| format!("{}", e))?
+                        .map_err(|e| format!("{e}"))?
                         .unwrap_term(),
                     CLoc::Member(inner_loc, field) => {
                         let base = self
                             .circ_get_value(inner_loc.loc().clone())
-                            .map_err(|e| format!("{}", e))?
+                            .map_err(|e| format!("{e}"))?
                             .unwrap_term();
                         self.field_select(&base, &field).unwrap()
                     }
                     CLoc::Idx(inner_loc, idx) => {
                         let base = self
                             .circ_get_value(inner_loc.loc().clone())
-                            .map_err(|e| format!("{}", e))?
+                            .map_err(|e| format!("{e}"))?
                             .unwrap_term();
                         self.array_select(&base, &idx).unwrap()
                     }
@@ -572,14 +572,14 @@ impl CGen {
                 let inner_loc = l.loc().clone();
                 let base = self
                     .circ_get_value(inner_loc.clone())
-                    .map_err(|e| format!("{}", e))?
+                    .map_err(|e| format!("{e}"))?
                     .unwrap_term();
                 let old_inner = self.field_select(&base, &field)?;
                 let new_inner = self.rebuild_lval(old_inner, *l, val)?;
                 let res = self.field_store(&base, &field, &new_inner);
                 Ok(self
                     .circ_assign(inner_loc, Val::Term(res.unwrap()))
-                    .map_err(|e| format!("{}", e))?
+                    .map_err(|e| format!("{e}"))?
                     .unwrap_term())
             }
         }

--- a/src/front/c/term.rs
+++ b/src/front/c/term.rs
@@ -98,18 +98,18 @@ impl CTermData {
 impl Display for CTermData {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            CTermData::CBool(x) => write!(f, "Bool({})", x),
-            CTermData::CInt(_, _, x) => write!(f, "Int({})", x),
-            CTermData::CArray(t, _) => write!(f, "Array({:#?})", t),
-            CTermData::CStackPtr(t, s, _) => write!(f, "Ptr{:#?}({:#?})", s, t),
-            CTermData::CStruct(t, _) => write!(f, "Struct({})", t),
+            CTermData::CBool(x) => write!(f, "Bool({x})"),
+            CTermData::CInt(_, _, x) => write!(f, "Int({x})"),
+            CTermData::CArray(t, _) => write!(f, "Array({t:#?})"),
+            CTermData::CStackPtr(t, s, _) => write!(f, "Ptr{s:#?}({t:#?})"),
+            CTermData::CStruct(t, _) => write!(f, "Struct({t})"),
         }
     }
 }
 
 impl fmt::Debug for CTermData {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 
@@ -126,7 +126,7 @@ impl Display for CTerm {
 }
 
 fn field_name(struct_name: &str, field_name: &str) -> String {
-    format!("{}.{}", struct_name, field_name)
+    format!("{struct_name}.{field_name}")
 }
 
 pub fn cterm(data: CTermData) -> CTerm {
@@ -334,7 +334,7 @@ fn wrap_bin_arith(
             })
         }
 
-        (x, y, _, _) => Err(format!("Cannot perform op '{}' on {} and {}", name, x, y)),
+        (x, y, _, _) => Err(format!("Cannot perform op '{name}' on {x} and {y}")),
     }
 }
 
@@ -416,7 +416,7 @@ fn wrap_bin_logical(
             term: CTermData::CBool(fb(a, b)),
             udef: false,
         }),
-        (x, y, _, _) => Err(format!("Cannot perform op '{}' on {} and {}", name, x, y)),
+        (x, y, _, _) => Err(format!("Cannot perform op '{name}' on {x} and {y}")),
     }
 }
 
@@ -455,7 +455,7 @@ fn wrap_bin_cmp(
             term: CTermData::CBool(fb(x, y)),
             udef: false,
         }),
-        (x, y, _, _) => Err(format!("Cannot perform op '{}' on {} and {}", name, x, y)),
+        (x, y, _, _) => Err(format!("Cannot perform op '{name}' on {x} and {y}")),
     }
 }
 
@@ -533,7 +533,7 @@ fn wrap_shift(name: &str, op: BvBinOp, a: CTerm, b: CTerm) -> Result<CTerm, Stri
             term: CTermData::CInt(*s, *na, term![Op::BvBinOp(op); a.clone(), bv_lit(bc, *na)]),
             udef: false,
         }),
-        x => Err(format!("Cannot perform op '{}' on {} and {}", name, x, bc)),
+        x => Err(format!("Cannot perform op '{name}' on {x} and {bc}")),
     }
 }
 
@@ -548,7 +548,7 @@ pub fn shr(a: CTerm, b: CTerm) -> Result<CTerm, String> {
 pub struct Ct {}
 
 fn idx_name(struct_name: &str, idx: usize) -> String {
-    format!("{}.{}", struct_name, idx)
+    format!("{struct_name}.{idx}")
 }
 
 impl Ct {

--- a/src/front/c/types.rs
+++ b/src/front/c/types.rs
@@ -41,9 +41,9 @@ impl Display for Ty {
             Ty::Bool => write!(f, "bool"),
             Ty::Int(s, w) => {
                 if *s {
-                    write!(f, "s{}", w)
+                    write!(f, "s{w}")
                 } else {
-                    write!(f, "u{}", w)
+                    write!(f, "u{w}")
                 }
             }
             Ty::Struct(n, fields) => {
@@ -60,11 +60,11 @@ impl Display for Ty {
                     bb = b.as_ref();
                     dims.push(n);
                 }
-                write!(f, "{}", bb)?;
-                dims.iter().try_for_each(|d| write!(f, "[{}]", d))
+                write!(f, "{bb}")?;
+                dims.iter().try_for_each(|d| write!(f, "[{d}]"))
             }
             Ty::Ptr(s, t) => {
-                write!(f, "ptr{}({})", s, t)
+                write!(f, "ptr{s}({t})")
             }
         }
     }
@@ -72,7 +72,7 @@ impl Display for Ty {
 
 impl fmt::Debug for Ty {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/src/front/datalog/error.rs
+++ b/src/front/datalog/error.rs
@@ -40,7 +40,7 @@ impl<'ast> Display for Error<'ast> {
         if let Some(s) = &self.span {
             writeln!(f, "\nLocation:")?;
             for l in s.lines() {
-                writeln!(f, "  {}", l)?;
+                writeln!(f, "  {l}")?;
             }
         }
         Ok(())

--- a/src/front/datalog/mod.rs
+++ b/src/front/datalog/mod.rs
@@ -385,7 +385,7 @@ impl FrontEnd for Datalog {
         let ast = match ast {
             Ok(ast) => ast,
             Err(e) => {
-                println!("{}", e);
+                println!("{e}");
                 panic!("parse error!")
             }
         };
@@ -397,7 +397,7 @@ impl FrontEnd for Datalog {
             g.entry_rule("main")
         };
         if let Err(e) = r {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             panic!()
         }
         let mut cs = Computations::new();

--- a/src/front/datalog/term.rs
+++ b/src/front/datalog/term.rs
@@ -328,7 +328,7 @@ pub fn uint_to_field(s: &T) -> Result<T> {
 /// Uint to field
 pub fn array_idx(a: &T, i: &T) -> Result<T> {
     match (&a.ty, &i.ty) {
-        (&Ty::Array(_, ref elem_ty), &Ty::Field) => Ok(T::new(
+        (Ty::Array(_, elem_ty), &Ty::Field) => Ok(T::new(
             term![Op::Select; a.ir.clone(), i.ir.clone()],
             (**elem_ty).clone(),
         )),

--- a/src/front/datalog/ty.rs
+++ b/src/front/datalog/ty.rs
@@ -20,8 +20,8 @@ impl Display for Ty {
         match &self {
             Ty::Bool => write!(f, "bool"),
             Ty::Field => write!(f, "field"),
-            Ty::Uint(w) => write!(f, "u{}", w),
-            Ty::Array(l, t) => write!(f, "{}[{}]", t, l),
+            Ty::Uint(w) => write!(f, "u{w}"),
+            Ty::Array(l, t) => write!(f, "{t}[{l}]"),
         }
     }
 }

--- a/src/front/mod.rs
+++ b/src/front/mod.rs
@@ -44,10 +44,10 @@ pub enum Mode {
 impl Display for Mode {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
-            Mode::Mpc(n) => write!(f, "{}-pc", n),
+            Mode::Mpc(n) => write!(f, "{n}-pc"),
             Mode::Proof => write!(f, "proof"),
             Mode::Opt => write!(f, "opt"),
-            Mode::ProofOfHighValue(v) => write!(f, "proof_of_high_value({})", v),
+            Mode::ProofOfHighValue(v) => write!(f, "proof_of_high_value({v})"),
         }
     }
 }

--- a/src/front/zsharp/zvisit/eqtype.rs
+++ b/src/front/zsharp/zvisit/eqtype.rs
@@ -16,8 +16,7 @@ pub(super) fn eq_type<'ast>(
         (Array(aty), Array(aty2)) => eq_array_type(aty, aty2, zgen),
         (Struct(sty), Struct(sty2)) => eq_struct_type(sty, sty2, zgen),
         _ => Err(ZVisitorError(format!(
-            "type mismatch: expected {:?}, found {:?}",
-            ty, ty2,
+            "type mismatch: expected {ty:?}, found {ty2:?}"
         ))),
     }
 }
@@ -32,8 +31,7 @@ fn eq_basic_type<'ast>(ty: &ast::BasicType<'ast>, ty2: &ast::BasicType<'ast>) ->
         (U32(_), U32(_)) => Ok(()),
         (U64(_), U64(_)) => Ok(()),
         _ => Err(ZVisitorError(format!(
-            "basic type mismatch: expected {:?}, found {:?}",
-            ty, ty2,
+            "basic type mismatch: expected {ty:?}, found {ty2:?}"
         ))),
     }
 }
@@ -79,7 +77,7 @@ fn eq_struct_type<'ast>(
     }
 }
 
-fn is_struct<'ast>(id: &str, zgen: &ZGen<'ast>) -> bool {
+fn is_struct(id: &str, zgen: &ZGen<'_>) -> bool {
     zgen.get_struct_or_type(id)
         .map(|(s, _)| s.is_ok())
         .unwrap_or(false)

--- a/src/front/zsharp/zvisit/zgenericinf.rs
+++ b/src/front/zsharp/zvisit/zgenericinf.rs
@@ -215,8 +215,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
                 .type_impl_::<IS_CNST>(&ast::Type::Basic(bas_ty.clone()))?
         {
             Err(format!(
-                "Type mismatch unifying generics: got {}, decl was {:?}",
-                arg_ty, bas_ty
+                "Type mismatch unifying generics: got {arg_ty}, decl was {bas_ty:?}"
             ))
         } else {
             Ok(())
@@ -230,8 +229,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
     ) -> Result<(), String> {
         if !matches!(arg_ty, Ty::Array(_, _)) {
             return Err(format!(
-                "Type mismatch unifying generics: got {}, decl was Array",
-                arg_ty
+                "Type mismatch unifying generics: got {arg_ty}, decl was Array",
             ));
         }
 
@@ -359,12 +357,11 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
                         Ok(aty_map.into_map())
                     }
                     Ty::Struct(aty_n, _) => Err(format!(
-                        "Type mismatch: got struct {}, decl was struct {}",
-                        &aty_n, &def_ty.id.value
+                        "Type mismatch: got struct {aty_n}, decl was struct {}",
+                        &def_ty.id.value
                     )),
                     arg_ty => Err(format!(
-                        "Type mismatch unifying generics: got {}, decl was Struct",
-                        arg_ty
+                        "Type mismatch unifying generics: got {arg_ty}, decl was Struct",
                     )),
                 }?;
                 for ast::StructField { ty, id, .. } in strdef.fields.iter() {
@@ -452,8 +449,7 @@ fn u32_term(t: T) -> Result<Term, String> {
     match t.ty {
         Ty::Uint(32) => Ok(t.term),
         ty => Err(format!(
-            "ZGenericInf: got {} for expr, expected T::Uint(32)",
-            ty
+            "ZGenericInf: got {ty} for expr, expected T::Uint(32)"
         )),
     }
 }

--- a/src/front/zsharp/zvisit/zstmtwalker/mod.rs
+++ b/src/front/zsharp/zvisit/zstmtwalker/mod.rs
@@ -625,7 +625,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
     fn get_function(&self, id: &str) -> ZResult<&ast::FunctionDefinition<'ast>> {
         self.zgen
             .get_function(id)
-            .ok_or_else(|| ZVisitorError(format!("ZStatementWalker: undeclared function {}", id)))
+            .ok_or_else(|| ZVisitorError(format!("ZStatementWalker: undeclared function {id}")))
     }
 
     fn get_struct_or_type(
@@ -682,13 +682,11 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
     {
         if self.generic_defined(nm) {
             Err(ZVisitorError(format!(
-                "ZStatementWalker: attempted to shadow generic {}",
-                nm,
+                "ZStatementWalker: attempted to shadow generic {nm}"
             )))
         } else if self.const_defined(nm) {
             Err(ZVisitorError(format!(
-                "ZStatementWalker: attempted to shadow const {}",
-                nm,
+                "ZStatementWalker: attempted to shadow const {nm}"
             )))
         } else {
             Ok(f(self, nm))

--- a/src/front/zsharp/zvisit/zstmtwalker/zexprtyper.rs
+++ b/src/front/zsharp/zvisit/zstmtwalker/zexprtyper.rs
@@ -273,8 +273,7 @@ impl<'ast, 'ret, 'wlk> ZVisitorMut<'ast> for ZExpressionTyper<'ast, 'ret, 'wlk> 
                         }
                     } else {
                         Err(format!(
-                            "ZExpressionTyper: Spread expression: expected array, got {:?}",
-                            ty
+                            "ZExpressionTyper: Spread expression: expected array, got {ty:?}"
                         ))
                     }?;
 
@@ -291,8 +290,7 @@ impl<'ast, 'ret, 'wlk> ZVisitorMut<'ast> for ZExpressionTyper<'ast, 'ret, 'wlk> 
                     Ok(())
                 } else {
                     Err(ZVisitorError(format!(
-                        "ZExpressionTyper: Could not type SpreadOrExpression::Spread {:#?}",
-                        soe
+                        "ZExpressionTyper: Could not type SpreadOrExpression::Spread {soe:#?}",
                     )))
                 }
             })?;
@@ -303,7 +301,7 @@ impl<'ast, 'ret, 'wlk> ZVisitorMut<'ast> for ZExpressionTyper<'ast, 'ret, 'wlk> 
                 ast::Expression::Literal(ast::LiteralExpression::HexLiteral(
                     ast::HexLiteralExpression {
                         value: ast::HexNumberExpression::U32(ast::U32NumberExpression {
-                            value: format!("{:04x}", acc_len),
+                            value: format!("{acc_len:04x}"),
                             span: iae.span,
                         }),
                         span: iae.span,

--- a/src/ir/opt/cfold.rs
+++ b/src/ir/opt/cfold.rs
@@ -123,8 +123,8 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<TTerm>, ignore: &[Op]) -> T
                     if let FieldToBv::Panic = cfg().ir.field_to_bv {
                         assert!(
                             (i.significant_bits() as usize) <= *w,
-                            "oversized input to Op::PfToBv({})",
-                            w
+                            "{}",
+                            "oversized input to Op::PfToBv({w})",
                         );
                     }
                     bv_lit(i % (Integer::from(1) << *w), *w)
@@ -614,7 +614,7 @@ mod test {
         let tt = fold(&t, &[]);
         let orig = eval(&t, &vs);
         let new = eval(&tt, &vs);
-        assert!(orig == new, "{} ({}) vs {} ({})", t, orig, tt, new);
+        assert!(orig == new, "{}", "{t} ({orig}) vs {tt} ({new})");
     }
 
     #[test]

--- a/src/ir/opt/inline.rs
+++ b/src/ir/opt/inline.rs
@@ -47,43 +47,35 @@ impl<'a> Inliner<'a> {
             for child in PostOrderIter::new(value.clone()) {
                 assert!(
                     !keys.contains(&child),
-                    "Substituted variable {} is in the substitution for {}, {}",
-                    child,
-                    key,
-                    value
+                    "{}",
+                    "Substituted variable {child} is in the substitution for {key}, {value}"
                 );
                 if child.is_var() {
                     assert!(
                         self.stale_vars.contains(&child),
-                        "Variable {} in the substitution for {}, {} is not marked stale",
-                        child,
-                        key,
-                        value
+                        "{}",
+                        "Variable {child} in the substitution for {key}, {value} is not marked stale"
                     );
                 }
             }
             assert!(
                 self.stale_vars.contains(key),
-                "Variable {}, which is being susbstituted",
-                key
+                "{}",
+                "Variable {key}, which is being susbstituted",
             );
         }
         for (key, value) in &self.subst_cache {
             for child in PostOrderIter::new(value.clone()) {
                 assert!(
                     !keys.contains(&child),
-                    "Substituted variable {} is in the cache for {}, {}",
-                    child,
-                    key,
-                    value
+                    "{}",
+                    format!("Substituted variable {child} is in the cache for {key}, {value}"),
                 );
                 if child.is_var() {
                     assert!(
                         self.stale_vars.contains(&child),
-                        "Variable {} in the substitution cache for {}, {} is not marked stale",
-                        child,
-                        key,
-                        value
+                        "{}",
+                        format!("Variable {child} in the substitution cache for {key}, {value} is not marked stale")
                     );
                 }
             }

--- a/src/ir/opt/mem/lin.rs
+++ b/src/ir/opt/mem/lin.rs
@@ -32,7 +32,7 @@ impl RewritePass for Linearizer {
             Op::Const(v @ Value::Array(..)) => Some(leaf_term(Op::Const(arr_val_to_tup(v)))),
             Op::Var(name, Sort::Array(..)) => {
                 let precomp = extras::array_to_tuple(orig);
-                let new_name = format!("{}.tup", name);
+                let new_name = format!("{name}.tup");
                 let new_sort = check(&precomp);
                 computation.extend_precomputation(new_name.clone(), precomp);
                 Some(leaf_term(Op::Var(new_name, new_sort)))

--- a/src/ir/opt/mem/obliv.rs
+++ b/src/ir/opt/mem/obliv.rs
@@ -240,7 +240,7 @@ impl RewritePass for Replacer {
             Op::Var(name, Sort::Array(..)) => {
                 if self.should_replace(orig) {
                     let precomp = extras::array_to_tuple(orig);
-                    let new_name = format!("{}.tup", name);
+                    let new_name = format!("{name}.tup");
                     let new_sort = check(&precomp);
                     computation.extend_precomputation(new_name.clone(), precomp);
                     Some(leaf_term(Op::Var(new_name, new_sort)))

--- a/src/ir/opt/mod.rs
+++ b/src/ir/opt/mod.rs
@@ -72,7 +72,7 @@ pub fn opt<I: IntoIterator<Item = Opt>>(mut cs: Computations, optimizations: I) 
                 Opt::FlattenAssertions => {
                     let mut new_outputs = Vec::new();
                     for a in std::mem::take(&mut c.outputs) {
-                        assert_eq!(check(&a), Sort::Bool, "Non-bool in {:?}", i);
+                        assert_eq!(check(&a), Sort::Bool, "Non-bool in {i:?}");
                         if a.op() == &Op::BoolNaryOp(BoolNaryOp::And) {
                             new_outputs.extend(a.cs().iter().cloned());
                         } else {

--- a/src/ir/opt/scalarize_vars.rs
+++ b/src/ir/opt/scalarize_vars.rs
@@ -21,7 +21,7 @@ fn create_vars(
                 .enumerate()
                 .map(|(i, sort)| {
                     create_vars(
-                        &format!("{}.{}", prefix, i),
+                        &format!("{prefix}.{i}"),
                         term![Op::Field(i); prefix_term.clone()],
                         sort,
                         new_var_requests,
@@ -39,7 +39,7 @@ fn create_vars(
                     .zip(array_elements)
                     .map(|(i, element)| {
                         create_vars(
-                            &format!("{}.{}", prefix, i),
+                            &format!("{prefix}.{i}"),
                             element,
                             val_s,
                             new_var_requests,

--- a/src/ir/opt/sha.rs
+++ b/src/ir/opt/sha.rs
@@ -227,7 +227,7 @@ mod test {
     fn catch_all_case() {
         let abc_term_rewrites = |t: &str| -> bool {
             contains_ite(&sha_rewrites(&parse_term(
-                format!("(declare ((a (bv 4))(b (bv 4))(c (bv 4))) {})", t).as_bytes(),
+                format!("(declare ((a (bv 4))(b (bv 4))(c (bv 4))) {t})").as_bytes(),
             )))
         };
         assert!(abc_term_rewrites("(bvor (bvand a b) (bvand (bvnot a) c))"));

--- a/src/ir/term/dist.rs
+++ b/src/ir/term/dist.rs
@@ -120,7 +120,7 @@ impl FixedSizeDist {
             }
             Sort::BitVector(w) => vec![
                 self.sample_value(sort, rng),
-                Op::Var(self.sample_ident(&format!("bv{}", w), rng), sort.clone()),
+                Op::Var(self.sample_ident(&format!("bv{w}"), rng), sort.clone()),
                 Op::BvUnOp(BvUnOp::Neg),
                 Op::BvUnOp(BvUnOp::Not),
                 Op::BvUext(rng.gen_range(0..*w)),
@@ -152,7 +152,7 @@ impl FixedSizeDist {
                     // No variables!
                     Op::Var(
                         self.sample_ident(
-                            &format!("tp_{}", sort)
+                            &format!("tp_{sort}")
                                 .replace('(', "[")
                                 .replace(')', "]")
                                 .replace(' ', "_"),

--- a/src/ir/term/extras.rs
+++ b/src/ir/term/extras.rs
@@ -124,7 +124,7 @@ pub fn assert_all_vars_declared(c: &Computation) {
     let vars: FxHashSet<String> = c.metadata.vars.iter().map(|p| p.0.clone()).collect();
     for o in &c.outputs {
         for v in free_variables(o.clone()) {
-            assert!(vars.contains(&v), "Variable {} is not declared", v);
+            assert!(vars.contains(&v), "{}", "Variable {v} is not declared");
         }
     }
 }

--- a/src/ir/term/fmt.rs
+++ b/src/ir/term/fmt.rs
@@ -89,7 +89,7 @@ impl<'a, 'b> IrFormatter<'a, 'b> {
         }
     }
     fn write_def(&mut self, id: usize) -> FmtResult {
-        write!(self.writer, "'{}", id)
+        write!(self.writer, "'{id}")
     }
     /// returns whether the term was def'd and written.
     fn term_write_if_def(&mut self, t: &Term) -> Result<bool, FmtError> {
@@ -121,7 +121,7 @@ impl DisplayIr for Sort {
     fn ir_fmt(&self, f: &mut IrFormatter) -> FmtResult {
         match self {
             Sort::Bool => write!(f, "bool"),
-            Sort::BitVector(n) => write!(f, "(bv {})", n),
+            Sort::BitVector(n) => write!(f, "(bv {n})"),
             Sort::Int => write!(f, "int"),
             Sort::F32 => write!(f, "f32"),
             Sort::F64 => write!(f, "f64"),
@@ -132,7 +132,7 @@ impl DisplayIr for Sort {
                 k.ir_fmt(f)?;
                 write!(f, " ")?;
                 v.ir_fmt(f)?;
-                write!(f, " {})", n)
+                write!(f, " {n})")
             }
             Sort::Tuple(fields) => {
                 write!(f, "(tuple")?;
@@ -151,48 +151,48 @@ impl DisplayIr for Op {
         match self {
             Op::Ite => write!(f, "ite"),
             Op::Eq => write!(f, "="),
-            Op::Var(n, _) => write!(f, "{}", n),
+            Op::Var(n, _) => write!(f, "{n}"),
             Op::Const(c) => c.ir_fmt(f),
-            Op::BvBinOp(a) => write!(f, "{}", a),
-            Op::BvBinPred(a) => write!(f, "{}", a),
-            Op::BvNaryOp(a) => write!(f, "{}", a),
-            Op::BvUnOp(a) => write!(f, "{}", a),
+            Op::BvBinOp(a) => write!(f, "{a}"),
+            Op::BvBinPred(a) => write!(f, "{a}"),
+            Op::BvNaryOp(a) => write!(f, "{a}"),
+            Op::BvUnOp(a) => write!(f, "{a}"),
             Op::BoolToBv => write!(f, "bool2bv"),
-            Op::BvExtract(a, b) => write!(f, "(extract {} {})", a, b),
+            Op::BvExtract(a, b) => write!(f, "(extract {a} {b})"),
             Op::BvConcat => write!(f, "concat"),
-            Op::BvUext(a) => write!(f, "(uext {})", a),
-            Op::BvSext(a) => write!(f, "(sext {})", a),
-            Op::PfToBv(a) => write!(f, "(pf2bv {})", a),
+            Op::BvUext(a) => write!(f, "(uext {a})"),
+            Op::BvSext(a) => write!(f, "(sext {a})"),
+            Op::PfToBv(a) => write!(f, "(pf2bv {a})"),
             Op::Implies => write!(f, "=>"),
-            Op::BoolNaryOp(a) => write!(f, "{}", a),
+            Op::BoolNaryOp(a) => write!(f, "{a}"),
             Op::Not => write!(f, "not"),
-            Op::BvBit(a) => write!(f, "(bit {})", a),
+            Op::BvBit(a) => write!(f, "(bit {a})"),
             Op::BoolMaj => write!(f, "maj"),
-            Op::FpBinOp(a) => write!(f, "{}", a),
-            Op::FpBinPred(a) => write!(f, "{}", a),
-            Op::FpUnPred(a) => write!(f, "{}", a),
-            Op::FpUnOp(a) => write!(f, "{}", a),
+            Op::FpBinOp(a) => write!(f, "{a}"),
+            Op::FpBinPred(a) => write!(f, "{a}"),
+            Op::FpUnPred(a) => write!(f, "{a}"),
+            Op::FpUnOp(a) => write!(f, "{a}"),
             Op::BvToFp => write!(f, "bv2fp"),
-            Op::UbvToFp(a) => write!(f, "(ubv2fp {})", a),
-            Op::SbvToFp(a) => write!(f, "(sbv2fp {})", a),
-            Op::FpToFp(a) => write!(f, "(fp2fp {})", a),
-            Op::PfUnOp(a) => write!(f, "{}", a),
-            Op::PfNaryOp(a) => write!(f, "{}", a),
-            Op::IntNaryOp(a) => write!(f, "{}", a),
-            Op::IntBinPred(a) => write!(f, "{}", a),
+            Op::UbvToFp(a) => write!(f, "(ubv2fp {a})"),
+            Op::SbvToFp(a) => write!(f, "(sbv2fp {a})"),
+            Op::FpToFp(a) => write!(f, "(fp2fp {a})"),
+            Op::PfUnOp(a) => write!(f, "{a}"),
+            Op::PfNaryOp(a) => write!(f, "{a}"),
+            Op::IntNaryOp(a) => write!(f, "{a}"),
+            Op::IntBinPred(a) => write!(f, "{a}"),
             Op::UbvToPf(a) => write!(f, "(bv2pf {})", a.modulus()),
             Op::Select => write!(f, "select"),
             Op::Store => write!(f, "store"),
             Op::Tuple => write!(f, "tuple"),
-            Op::Field(i) => write!(f, "(field {})", i),
-            Op::Update(i) => write!(f, "(update {})", i),
+            Op::Field(i) => write!(f, "(field {i})"),
+            Op::Update(i) => write!(f, "(update {i})"),
             Op::Map(op) => {
                 write!(f, "(map(")?;
                 op.ir_fmt(f)?;
                 write!(f, "))")
             }
-            Op::Call(name, _, _) => write!(f, "fn:{}", name),
-            Op::Rot(i) => write!(f, "(rot {})", i),
+            Op::Call(name, _, _) => write!(f, "fn:{name}"),
+            Op::Rot(i) => write!(f, "(rot {i})"),
         }
     }
 }
@@ -200,12 +200,12 @@ impl DisplayIr for Op {
 impl DisplayIr for Value {
     fn ir_fmt(&self, f: &mut IrFormatter) -> FmtResult {
         match self {
-            Value::Bool(b) => write!(f, "{}", b),
-            Value::F32(b) => write!(f, "{}", b),
-            Value::F64(b) => write!(f, "{}", b),
-            Value::Int(b) => write!(f, "{}", b),
+            Value::Bool(b) => write!(f, "{b}"),
+            Value::F32(b) => write!(f, "{b}"),
+            Value::F64(b) => write!(f, "{b}"),
+            Value::Int(b) => write!(f, "{b}"),
             Value::Field(b) => b.ir_fmt(f),
-            Value::BitVector(b) => write!(f, "{}", b),
+            Value::BitVector(b) => write!(f, "{b}"),
             Value::Tuple(fields) => {
                 write!(f, "(#t ")?;
                 for field in fields.iter() {
@@ -253,7 +253,7 @@ impl DisplayIr for FieldV {
         if i.significant_bits() + 1 >= mod_bits {
             i -= self.modulus();
         }
-        write!(f, "#f{}", i)?;
+        write!(f, "#f{i}")?;
         if !omit_field {
             write!(f, "m{}", self.modulus())?;
         }
@@ -286,7 +286,7 @@ impl DisplayIr for VariableMetadata {
         write!(f, "({} ", self.name)?;
         self.sort.ir_fmt(f)?;
         if let Some(v) = self.vis.as_ref() {
-            write!(f, " (party {})", v)?;
+            write!(f, " (party {v})")?;
         }
         if 0 != self.round {
             write!(f, " (round {})", self.round)?;
@@ -308,7 +308,7 @@ impl DisplayIr for ComputationMetadata {
             .collect();
         for id in 0..self.party_ids.len() as u8 {
             let party = ids_to_parties.get(&id).unwrap();
-            write!(f, " {}", party)?;
+            write!(f, " {party}")?;
         }
         writeln!(f, ")")?;
         write!(f, "\n  (inputs")?;
@@ -353,7 +353,7 @@ fn fmt_term_with_bindings(t: &Term, f: &mut IrFormatter) -> FmtResult {
             *parent_counts.entry(c).or_insert(0) += 1;
         }
         if let Op::Var(name, sort) = &t.op() {
-            write!(f, "  ({} ", name)?;
+            write!(f, "  ({name} ")?;
             sort.ir_fmt(f)?;
             writeln!(f, ")")?;
         }
@@ -382,7 +382,7 @@ fn fmt_term_with_bindings(t: &Term, f: &mut IrFormatter) -> FmtResult {
 
 impl<'a> Display for IrWrapper<'a, Term> {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -404,7 +404,7 @@ impl Debug for Term {
 
 impl Display for Term {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/ir/term/mod.rs
+++ b/src/ir/term/mod.rs
@@ -1300,8 +1300,8 @@ fn eval_value(vs: &mut TermMap<Value>, h: &FxHashMap<String, Value>, c: Term) ->
             if let FieldToBv::Panic = cfg().ir.field_to_bv {
                 assert!(
                     (i.significant_bits() as usize) <= *w,
-                    "oversized input to Op::PfToBv({})",
-                    w
+                    "{}",
+                    "oversized input to Op::PfToBv({w})",
                 );
             }
             BitVector::new(i % (Integer::from(1) << *w), *w)

--- a/src/ir/term/text/mod.rs
+++ b/src/ir/term/text/mod.rs
@@ -92,7 +92,7 @@ impl<'src> Display for TokTree<'src> {
                     } else {
                         write!(f, " ")?;
                     }
-                    write!(f, "{}", tt)?;
+                    write!(f, "{tt}")?;
                 }
                 write!(f, ")")
             }
@@ -460,8 +460,7 @@ impl<'src> IrInterp<'src> {
                         assert_eq!(
                             tts.len(),
                             3,
-                            "A decl should have 2 arguments: (declare ((v1 s1) ... (vn sn)) t), found {:#?}",
-                            tts
+                            "A decl should have 2 arguments: (declare ((v1 s1) ... (vn sn)) t), found {tts:#?}",
                         );
                         let bindings = self.decl_list(&tts[1]);
                         let t = self.term(&tts[2]);
@@ -756,7 +755,7 @@ pub fn serialize_value_map(src: &HashMap<String, Value>) -> String {
     let mut out = String::new();
     writeln!(&mut out, "(let (").unwrap();
     for (var, val) in src {
-        writeln!(&mut out, "  ({} {})", var, val).unwrap();
+        writeln!(&mut out, "  ({var} {val})").unwrap();
     }
     writeln!(&mut out, ") true;ignored \n)").unwrap();
     out
@@ -786,11 +785,11 @@ pub fn serialize_precompute(p: &precomp::PreComp) -> String {
     let mut out = String::new();
     writeln!(&mut out, "(precompute (").unwrap();
     for (name, sort) in p.inputs() {
-        writeln!(&mut out, " ({} {})", name, sort).unwrap();
+        writeln!(&mut out, " ({name} {sort})").unwrap();
     }
     writeln!(&mut out, ")(").unwrap();
     for (name, sort) in p.sequence() {
-        writeln!(&mut out, " ({} {})", name, sort).unwrap();
+        writeln!(&mut out, " ({name} {sort})").unwrap();
     }
     writeln!(&mut out, ")").unwrap();
     writeln!(&mut out, "\n  {}", serialize_term(&p.tuple())).unwrap();
@@ -880,7 +879,7 @@ mod test {
                 ((field 0) (#t false false #b0000 true)))))",
         );
         let s = serialize_term(&t);
-        println!("{}", s);
+        println!("{s}");
         let t2 = parse_term(s.as_bytes());
         assert_eq!(t, t2);
     }

--- a/src/ir/term/ty.rs
+++ b/src/ir/term/ty.rs
@@ -113,8 +113,7 @@ fn check_raw_step(t: &Term, tys: &TypeTable) -> Result<Sort, TypeErrorReason> {
             Ok(Sort::BitVector(32)) => Ok(Sort::F32),
             Ok(Sort::BitVector(64)) => Ok(Sort::F64),
             Ok(s) => Err(TypeErrorReason::Custom(format!(
-                "Cannot convert {} to floating-point",
-                s
+                "Cannot convert {s} to floating-point"
             ))),
             Err(e) => Err(e),
         },
@@ -139,8 +138,7 @@ fn check_raw_step(t: &Term, tys: &TypeTable) -> Result<Sort, TypeErrorReason> {
                 Ok(sorts[*i].clone())
             } else {
                 Err(TypeErrorReason::OutOfBounds(format!(
-                    "index {} in tuple of sort {}",
-                    i, sort
+                    "index {i} in tuple of sort {sort}"
                 )))
             }
         }
@@ -183,7 +181,7 @@ fn check_raw_step(t: &Term, tys: &TypeTable) -> Result<Sort, TypeErrorReason> {
         }
         Op::Call(_, _, ret) => Ok(ret.clone()),
         Op::Rot(_) => Ok(get_ty(&t.cs()[0]).clone()),
-        o => Err(TypeErrorReason::Custom(format!("other operator: {}", o))),
+        o => Err(TypeErrorReason::Custom(format!("other operator: {o}"))),
     }
 }
 
@@ -263,8 +261,7 @@ pub fn rec_check_raw_helper(oper: &Op, a: &[&Sort]) -> Result<Sort, TypeErrorRea
                 Ok(Sort::BitVector(high - low + 1))
             } else {
                 Err(TypeErrorReason::OutOfBounds(format!(
-                    "Cannot slice from {} to {} in a bit-vector of width {}",
-                    high, low, w
+                    "Cannot slice from {high} to {low} in a bit-vector of width {w}"
                 )))
             }
         }
@@ -296,8 +293,7 @@ pub fn rec_check_raw_helper(oper: &Op, a: &[&Sort]) -> Result<Sort, TypeErrorRea
                 Ok(Sort::Bool)
             } else {
                 Err(TypeErrorReason::OutOfBounds(format!(
-                    "Cannot get bit {} of a {}-bit bit-vector",
-                    i, w
+                    "Cannot get bit {i} of a {w}-bit bit-vector"
                 )))
             }
         }
@@ -356,8 +352,7 @@ pub fn rec_check_raw_helper(oper: &Op, a: &[&Sort]) -> Result<Sort, TypeErrorRea
                 Ok(t[*i].clone())
             } else {
                 Err(TypeErrorReason::OutOfBounds(format!(
-                    "index {} in tuple of sort {}",
-                    i, a
+                    "index {i} in tuple of sort {a}"
                 )))
             }
         }),
@@ -367,8 +362,7 @@ pub fn rec_check_raw_helper(oper: &Op, a: &[&Sort]) -> Result<Sort, TypeErrorRea
                 Ok(a.clone())
             } else {
                 Err(TypeErrorReason::OutOfBounds(format!(
-                    "index {} in tuple of sort {}",
-                    i, a
+                    "index {i} in tuple of sort {a}"
                 )))
             }
         }),

--- a/src/target/aby/trans.rs
+++ b/src/target/aby/trans.rs
@@ -182,13 +182,13 @@ impl<'a> ToABY<'a> {
                 Op::Const(Value::BitVector(b)) => {
                     let value = b.as_sint();
                     let bitlen = 32;
-                    let line = format!("2 1 {} {} {} {}\n", value, bitlen, output_share, op);
+                    let line = format!("2 1 {value} {bitlen} {output_share} {op}\n");
                     self.const_output.push(line);
                 }
                 Op::Const(Value::Bool(b)) => {
                     let value = *b as i32;
                     let bitlen = 1;
-                    let line = format!("2 1 {} {} {} {}\n", value, bitlen, output_share, op);
+                    let line = format!("2 1 {value} {bitlen} {output_share} {op}\n");
                     self.const_output.push(line);
                 }
                 _ => todo!(),
@@ -206,7 +206,7 @@ impl<'a> ToABY<'a> {
 
     fn write_share(&mut self, t: &Term, s: i32) {
         let share_type = self.get_term_share_type(t).char();
-        let line = format!("{} {}\n", s, share_type);
+        let line = format!("{s} {share_type}\n");
         self.share_output.push(line);
     }
 
@@ -269,7 +269,7 @@ impl<'a> ToABY<'a> {
         let s = self.get_share(t, to_share_type);
         if let std::collections::hash_map::Entry::Vacant(e) = self.cache.entry(key.clone()) {
             e.insert(s);
-            let line = format!("2 1 {} {} {} {}\n", a, b, s, op);
+            let line = format!("2 1 {a} {b} {s} {op}\n");
             self.bytecode_output.push(line);
         } else {
             let s = *self.cache.get(&key).unwrap();
@@ -289,10 +289,10 @@ impl<'a> ToABY<'a> {
 
                     if vis == PUBLIC {
                         let bitlen = 1;
-                        let line = format!("3 1 {} {} {} {} {}\n", name, vis, bitlen, s, op);
+                        let line = format!("3 1 {name} {vis} {bitlen} {s} {op}\n");
                         self.bytecode_input.push(line);
                     } else {
-                        let line = format!("2 1 {} {} {} {}\n", name, vis, s, op);
+                        let line = format!("2 1 {name} {vis} {s} {op}\n");
                         self.bytecode_input.push(line);
                     }
                     self.inputs.push(t.clone());
@@ -316,7 +316,7 @@ impl<'a> ToABY<'a> {
                 if let std::collections::hash_map::Entry::Vacant(e) = self.cache.entry(key.clone())
                 {
                     e.insert(s);
-                    let line = format!("3 1 {} {} {} {} {}\n", sel, a, b, s, op);
+                    let line = format!("3 1 {sel} {a} {b} {s} {op}\n");
                     self.bytecode_output.push(line);
                 } else {
                     let s = *self.cache.get(&key).unwrap();
@@ -332,7 +332,7 @@ impl<'a> ToABY<'a> {
                 if let std::collections::hash_map::Entry::Vacant(e) = self.cache.entry(key.clone())
                 {
                     e.insert(s);
-                    let line = format!("1 1 {} {} {}\n", a, s, op);
+                    let line = format!("1 1 {a} {s} {op}\n");
                     self.bytecode_output.push(line);
                 } else {
                     let s = *self.cache.get(&key).unwrap();
@@ -368,7 +368,7 @@ impl<'a> ToABY<'a> {
                         self.cache.entry(key.clone())
                     {
                         e.insert(s);
-                        let line = format!("2 1 {} {} {} {}\n", a, b, s, op);
+                        let line = format!("2 1 {a} {b} {s} {op}\n");
                         self.bytecode_output.push(line);
                     } else {
                         let s = *self.cache.get(&key).unwrap();
@@ -393,7 +393,7 @@ impl<'a> ToABY<'a> {
                 if let std::collections::hash_map::Entry::Vacant(e) = self.cache.entry(key.clone())
                 {
                     e.insert(s);
-                    let line = format!("2 1 {} {} {} {}\n", a, b, s, op);
+                    let line = format!("2 1 {a} {b} {s} {op}\n");
                     self.bytecode_output.push(line);
                 } else {
                     let s = *self.cache.get(&key).unwrap();
@@ -416,10 +416,10 @@ impl<'a> ToABY<'a> {
 
                     if vis == PUBLIC {
                         let bitlen = 32;
-                        let line = format!("3 1 {} {} {} {} {}\n", name, vis, bitlen, s, op);
+                        let line = format!("3 1 {name} {vis} {bitlen} {s} {op}\n");
                         self.bytecode_input.push(line);
                     } else {
-                        let line = format!("2 1 {} {} {} {}\n", name, vis, s, op);
+                        let line = format!("2 1 {name} {vis} {s} {op}\n");
                         self.bytecode_input.push(line);
                     }
                     self.inputs.push(t.clone());
@@ -440,7 +440,7 @@ impl<'a> ToABY<'a> {
                 if let std::collections::hash_map::Entry::Vacant(e) = self.cache.entry(key.clone())
                 {
                     e.insert(s);
-                    let line = format!("3 1 {} {} {} {} {}\n", sel, a, b, s, op);
+                    let line = format!("3 1 {sel} {a} {b} {s} {op}\n");
                     self.bytecode_output.push(line);
                 } else {
                     let s = *self.cache.get(&key).unwrap();
@@ -463,7 +463,7 @@ impl<'a> ToABY<'a> {
                 if let std::collections::hash_map::Entry::Vacant(e) = self.cache.entry(key.clone())
                 {
                     e.insert(s);
-                    let line = format!("2 1 {} {} {} {}\n", a, b, s, op);
+                    let line = format!("2 1 {a} {b} {s} {op}\n");
                     self.bytecode_output.push(line);
                 } else {
                     let s = *self.cache.get(&key).unwrap();
@@ -491,7 +491,7 @@ impl<'a> ToABY<'a> {
                             self.cache.entry(key.clone())
                         {
                             e.insert(s);
-                            let line = format!("2 1 {} {} {} {}\n", a, b, s, op);
+                            let line = format!("2 1 {a} {b} {s} {op}\n");
                             self.bytecode_output.push(line);
                         } else {
                             let s = *self.cache.get(&key).unwrap();
@@ -513,7 +513,7 @@ impl<'a> ToABY<'a> {
                             self.cache.entry(key.clone())
                         {
                             e.insert(s);
-                            let line = format!("2 1 {} {} {} {}\n", a, const_shift_amount, s, op);
+                            let line = format!("2 1 {a} {const_shift_amount} {s} {op}\n");
                             self.bytecode_output.push(line);
                         } else {
                             let s = *self.cache.get(&key).unwrap();
@@ -528,7 +528,7 @@ impl<'a> ToABY<'a> {
                 let tuple_share = self.get_share(&t.cs()[0], to_share_type);
                 let field_share = self.get_share(&t, to_share_type);
                 let op = "FIELD";
-                let line = format!("2 1 {} {} {} {}\n", tuple_share, i, field_share, op);
+                let line = format!("2 1 {tuple_share} {i} {field_share} {op}\n");
                 self.bytecode_output.push(line);
                 self.term_to_shares.insert(t.clone(), field_share);
             }
@@ -541,15 +541,12 @@ impl<'a> ToABY<'a> {
                     let op = "SELECT_CONS";
                     let idx = bv.uint().to_usize().unwrap();
                     let len = self.get_sort_len(&check(&t.cs()[0]));
-                    assert!(idx < len, "idx: {}, len: {}", idx, len);
-                    format!("2 1 {} {} {} {}\n", array_share, idx, select_share, op)
+                    assert!(idx < len, "{}", "idx: {idx}, len: {len}");
+                    format!("2 1 {array_share} {idx} {select_share} {op}\n")
                 } else {
                     let op = "SELECT";
                     let idx_share = self.get_share(&t.cs()[1], to_share_type);
-                    format!(
-                        "2 1 {} {} {} {}\n",
-                        array_share, idx_share, select_share, op
-                    )
+                    format!("2 1 {array_share} {idx_share} {select_share} {op}\n",)
                 };
                 self.bytecode_output.push(line);
                 self.term_to_shares.insert(t.clone(), select_share);
@@ -639,7 +636,7 @@ impl<'a> ToABY<'a> {
                 let a = self.get_share(&t.cs()[1], to_share_type);
                 let b = self.get_share(&t.cs()[2], to_share_type);
 
-                let line = format!("3 1 {} {} {} {} {}\n", sel, a, b, mux_share, op);
+                let line = format!("3 1 {sel} {a} {b} {mux_share} {op}\n");
                 self.bytecode_output.push(line);
                 self.term_to_shares.insert(t.clone(), mux_share);
             }
@@ -655,18 +652,12 @@ impl<'a> ToABY<'a> {
                     let op = "STORE_CONS";
                     let idx = bv.uint().to_usize().unwrap();
                     let len = self.get_sort_len(&check(&t.cs()[0]));
-                    assert!(idx < len, "idx: {}, len: {}", idx, len);
-                    format!(
-                        "3 1 {} {} {} {} {}\n",
-                        array_share, idx, value_share, store_share, op
-                    )
+                    assert!(idx < len, "{}", "idx: {idx}, len: {len}");
+                    format!("3 1 {array_share} {idx} {value_share} {store_share} {op}\n",)
                 } else {
                     let op = "STORE";
                     let index_share = self.get_share(&t.cs()[1], to_share_type);
-                    format!(
-                        "3 1 {} {} {} {} {}\n",
-                        array_share, index_share, value_share, store_share, op
-                    )
+                    format!("3 1 {array_share} {index_share} {value_share} {store_share} {op}\n",)
                 };
                 self.bytecode_output.push(line);
                 self.term_to_shares.insert(t.clone(), store_share);
@@ -699,10 +690,7 @@ impl<'a> ToABY<'a> {
                     _ => panic!("Field op on non-tuple"),
                 };
 
-                let line = format!(
-                    "3 1 {} {} {} {} {}\n",
-                    tuple_share, offset, len, field_share, op
-                );
+                let line = format!("3 1 {tuple_share} {offset} {len} {field_share} {op}\n");
                 self.bytecode_output.push(line);
                 self.term_to_shares.insert(t.clone(), field_share);
             }
@@ -714,10 +702,7 @@ impl<'a> ToABY<'a> {
                 let update_share = self.get_share(&t, to_share_type);
 
                 let op = "UPDATE";
-                let line = format!(
-                    "3 1 {} {} {} {} {}\n",
-                    tuple_share, i, value_share, update_share, op
-                );
+                let line = format!("3 1 {tuple_share} {i} {value_share} {update_share} {op}\n",);
                 self.bytecode_output.push(line);
                 self.term_to_shares.insert(t.clone(), update_share);
             }
@@ -742,7 +727,7 @@ impl<'a> ToABY<'a> {
             }
             Op::Call(name, ..) => {
                 let call_share = self.get_share(&t, to_share_type);
-                let op = format!("CALL({})", name);
+                let op = format!("CALL({name})");
 
                 let mut arg_shares: Vec<i32> = Vec::new();
                 for c in t.cs().iter() {
@@ -806,7 +791,7 @@ impl<'a> ToABY<'a> {
             get_path(
                 self.path,
                 &self.lang,
-                &format!("{}_bytecode_output", name),
+                &format!("{name}_bytecode_output"),
                 true,
             );
 
@@ -816,7 +801,7 @@ impl<'a> ToABY<'a> {
                 let op = "OUT";
                 let to_share_type = self.get_term_share_type(t);
                 let share = self.get_share(t, to_share_type);
-                let line = format!("1 0 {} {}\n", share, op);
+                let line = format!("1 0 {share} {op}\n");
                 outputs.push(line);
             }
             self.bytecode_output.append(&mut outputs);
@@ -845,15 +830,14 @@ impl<'a> ToABY<'a> {
             self.bytecode_input = inputs;
 
             // write input bytecode
-            let bytecode_path =
-                get_path(self.path, &self.lang, &format!("{}_bytecode", name), true);
+            let bytecode_path = get_path(self.path, &self.lang, &format!("{name}_bytecode"), true);
             write_lines(&bytecode_path, &self.bytecode_input);
 
             // write output bytecode
             let bytecode_output_path = get_path(
                 self.path,
                 &self.lang,
-                &format!("{}_bytecode_output", name),
+                &format!("{name}_bytecode_output"),
                 false,
             );
             write_lines(&bytecode_output_path, &self.bytecode_output);

--- a/src/target/aby/utils.rs
+++ b/src/target/aby/utils.rs
@@ -23,14 +23,14 @@ pub fn get_path(path: &Path, lang: &str, t: &str, create: bool) -> String {
         .into_string()
         .unwrap();
 
-    let name = format!("{}_{}", filename, lang);
-    let dir_path = format!("scripts/aby_tests/tests/{}", name);
+    let name = format!("{filename}_{lang}");
+    let dir_path = format!("scripts/aby_tests/tests/{name}");
     match fs::create_dir_all(&dir_path) {
         Err(why) => panic!("couldn't create {}: {}", dir_path, why),
         Ok(file) => file,
     };
 
-    let file_path = format!("{}/{}_{}.txt", dir_path, name, t);
+    let file_path = format!("{dir_path}/{name}_{t}.txt");
     if create {
         match File::create(&file_path) {
             Err(why) => panic!("couldn't create {}: {}", file_path, why),

--- a/src/target/ilp/trans.rs
+++ b/src/target/ilp/trans.rs
@@ -151,7 +151,7 @@ impl ToMilp {
     /// Returns a bit decomposition of e, with the ones place in index 0.
     fn bit_decomp(&mut self, e: &Expression, n_bits: usize) -> Vec<Expression> {
         let bits: Vec<_> = (0..n_bits)
-            .map(|i| self.fresh_bit(&format!("bit{}", i)))
+            .map(|i| self.fresh_bit(&format!("bit{i}")))
             .collect();
         let sum = bits
             .iter()

--- a/src/target/r1cs/bellman.rs
+++ b/src/target/r1cs/bellman.rs
@@ -136,7 +136,7 @@ impl<'a, F: PrimeField> Circuit<F> for SynthInput<'a> {
         }
         for (i, (a, b, c)) in self.0.constraints.iter().enumerate() {
             cs.enforce(
-                || format!("con{}", i),
+                || format!("con{i}"),
                 |z| lc_to_bellman::<F, CS>(&vars, a, z),
                 |z| lc_to_bellman::<F, CS>(&vars, b, z),
                 |z| lc_to_bellman::<F, CS>(&vars, c, z),
@@ -300,8 +300,7 @@ where
         let sort2 = value.sort();
         assert_eq!(
             sort, &sort2,
-            "Sort mismatch for {}. Expected\n\t{} but got\n\t{}",
-            input, sort, sort2
+            "Sort mismatch for {input}. Expected\n\t{sort} but got\n\t{sort2}",
         );
     }
     let new_map = prover_data.precompute.eval(inputs_map);
@@ -362,13 +361,13 @@ mod test {
     #[quickcheck]
     fn int_to_ff_random(BlsScalar(i): BlsScalar) -> bool {
         let by_fn = int_to_ff::<Scalar>(i.clone());
-        let by_str = Scalar::from_str_vartime(&format!("{}", i)).unwrap();
+        let by_str = Scalar::from_str_vartime(&format!("{i}")).unwrap();
         by_fn == by_str
     }
 
     fn convert(i: Integer) {
         let by_fn = int_to_ff::<Scalar>(i.clone());
-        let by_str = Scalar::from_str_vartime(&format!("{}", i)).unwrap();
+        let by_str = Scalar::from_str_vartime(&format!("{i}")).unwrap();
         assert_eq!(by_fn, by_str);
     }
 

--- a/src/target/r1cs/mod.rs
+++ b/src/target/r1cs/mod.rs
@@ -472,8 +472,7 @@ impl VerifierData {
             let sort2 = value.sort();
             assert_eq!(
                 sort, &sort2,
-                "Sort mismatch for {}. Expected\n\t{} but got\n\t{}",
-                input, sort, sort2
+                "Sort mismatch for {input}. Expected\n\t{sort} but got\n\t{sort2}",
             );
         }
         let new_map = self.precompute.eval(value_map);

--- a/src/target/r1cs/opt.rs
+++ b/src/target/r1cs/opt.rs
@@ -206,7 +206,7 @@ mod test {
             let m = 101;
             let field = FieldT::from(Integer::from(m));
             let n_vars = g.size() + 1;
-            let vars: Vec<_> = (0..n_vars).map(|i| format!("v{}", i)).collect();
+            let vars: Vec<_> = (0..n_vars).map(|i| format!("v{i}")).collect();
             let mut values: FxHashMap<String, Value> = Default::default();
             let mut r1cs = R1cs::new(field.clone());
             let mut rng = rand::rngs::StdRng::seed_from_u64(u64::arbitrary(g));

--- a/src/target/r1cs/spartan.rs
+++ b/src/target/r1cs/spartan.rs
@@ -90,8 +90,7 @@ pub fn r1cs_to_spartan(
     .unwrap();
     assert_eq!(
         &s_mod, f_mod,
-        "\nR1CS has modulus \n{},\n but Spartan CS expects \n{}",
-        s_mod, f_mod
+        "\nR1CS has modulus \n{s_mod},\n but Spartan CS expects \n{f_mod}",
     );
 
     let values = eval_inputs(inputs_map, prover_data);
@@ -195,8 +194,7 @@ fn eval_inputs(
         let sort2 = value.sort();
         assert_eq!(
             sort, &sort2,
-            "Sort mismatch for {}. Expected\n\t{} but got\n\t{}",
-            input, sort, sort2
+            "Sort mismatch for {input}. Expected\n\t{sort} but got\n\t{sort2}",
         );
     }
     let new_map = prover_data.precompute.eval(inputs_map);

--- a/src/target/r1cs/trans.rs
+++ b/src/target/r1cs/trans.rs
@@ -146,7 +146,7 @@ impl<'cfg> ToR1cs<'cfg> {
             .map(|i| {
                 self.fresh_bit(
                     // We get the right repr here because of infinite two's complement.
-                    &format!("{}_b{}", d, i),
+                    &format!("{d}_b{i}"),
                     term![Op::BvBit(i); term![Op::PfToBv(n); x.0.clone()]],
                 )
             })

--- a/src/target/smt/mod.rs
+++ b/src/target/smt/mod.rs
@@ -43,11 +43,11 @@ impl<'a, T: Sort2Smt + 'a> Display for SmtSortDisp<'a, T> {
 impl Expr2Smt<()> for Value {
     fn expr_to_smt2<W: Write>(&self, w: &mut W, (): ()) -> SmtRes<()> {
         match self {
-            Value::Bool(b) => write!(w, "{}", b)?,
+            Value::Bool(b) => write!(w, "{b}")?,
             Value::Field(f) => write!(w, "#f{}m{}", f.i(), f.modulus())?,
-            Value::Int(i) if i >= &Integer::new() => write!(w, "{}", i)?,
+            Value::Int(i) if i >= &Integer::new() => write!(w, "{i}")?,
             Value::Int(i) => write!(w, "(- 0 {})", *i.as_neg())?,
-            Value::BitVector(b) => write!(w, "{}", b)?,
+            Value::BitVector(b) => write!(w, "{b}")?,
             Value::F32(f) => {
                 let (sign, exp, mant) = f.decompose_raw();
                 write!(w, "(fp #b{} #b", sign as u8)?;
@@ -109,7 +109,7 @@ impl Expr2Smt<()> for Term {
     fn expr_to_smt2<W: Write>(&self, w: &mut W, (): ()) -> SmtRes<()> {
         let s_expr_children = match &self.op() {
             Op::Var(n, _) => {
-                write!(w, "{}", n)?;
+                write!(w, "{n}")?;
                 false
             }
             Op::Eq => {
@@ -133,7 +133,7 @@ impl Expr2Smt<()> for Term {
                 true
             }
             Op::BvUext(s) => {
-                write!(w, "((_ zero_extend {})", s)?;
+                write!(w, "((_ zero_extend {s})")?;
                 true
             }
             Op::Const(c) => {
@@ -153,7 +153,7 @@ impl Expr2Smt<()> for Term {
                 true
             }
             Op::Field(i) => {
-                write!(w, "((_ tupSel {})", i)?;
+                write!(w, "((_ tupSel {i})")?;
                 true
             }
             Op::PfNaryOp(PfNaryOp::Mul) => {
@@ -177,7 +177,7 @@ impl Expr2Smt<()> for Term {
                 true
             }
             Op::IntBinPred(o) => {
-                write!(w, "({}", o)?;
+                write!(w, "({o}")?;
                 true
             }
             o => panic!("Cannot give {} to SMT solver", o),
@@ -195,7 +195,7 @@ impl Expr2Smt<()> for Term {
 impl Sort2Smt for Sort {
     fn sort_to_smt2<W: Write>(&self, w: &mut W) -> SmtRes<()> {
         match self {
-            Sort::BitVector(b) => write!(w, "(_ BitVec {})", b)?,
+            Sort::BitVector(b) => write!(w, "(_ BitVec {b})")?,
             Sort::Array(k, v, _size) => {
                 write!(w, "(Array {} {})", SmtSortDisp(&**k), SmtSortDisp(&**v))?;
             }


### PR DESCRIPTION
Updates to support [uninlined format args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)