### PR TITLE
Inline small elements in `FieldV`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
 name = "circ_fields"
 version = "0.1.0"
 dependencies = [
+ "datasize",
  "ff",
  "ff-derive-num",
  "ff_derive",
@@ -488,6 +489,27 @@ dependencies = [
  "serde",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "datasize"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c88ad90721dc8e2ebe1430ac2f59c5bdcd74478baa68da26f30f33b0fe997f11"
+dependencies = [
+ "datasize_derive",
+ "serde",
+]
+
+[[package]]
+name = "datasize_derive"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0415ec81945214410892a00d4b5dd4566f6263205184248e018a3fe384a61e"
+dependencies = [
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/circ_fields/Cargo.lock
+++ b/circ_fields/Cargo.lock
@@ -53,6 +53,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "circ_fields"
 version = "0.1.0"
 dependencies = [
+ "datasize",
  "ff",
  "ff-derive-num",
  "ff_derive",
@@ -62,6 +63,27 @@ dependencies = [
  "rand",
  "rug",
  "serde",
+]
+
+[[package]]
+name = "datasize"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c88ad90721dc8e2ebe1430ac2f59c5bdcd74478baa68da26f30f33b0fe997f11"
+dependencies = [
+ "datasize_derive",
+ "serde",
+]
+
+[[package]]
+name = "datasize_derive"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0415ec81945214410892a00d4b5dd4566f6263205184248e018a3fe384a61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/circ_fields/Cargo.toml
+++ b/circ_fields/Cargo.toml
@@ -14,6 +14,7 @@ paste = "1.0"
 rand = "0.8"
 rug = { version = "1.11", features = ["serde"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
+datasize = { version = "0.2", features = ["detailed"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/circ_fields/src/ff_field.rs
+++ b/circ_fields/src/ff_field.rs
@@ -2,6 +2,16 @@
 
 use paste::paste;
 
+macro_rules! i64_impl {
+    ($Trait: ident, $fn: ident, $Ty: ident) => {
+        impl $Trait<i64> for $Ty {
+            fn $fn(&mut self, other: i64) {
+                self.$fn($Ty::from(other));
+            }
+        }
+    };
+}
+
 macro_rules! def_field {
     ($name: ident, $mod: literal, $gen: literal, $limbs: literal) => {
         paste! { pub use $name::Ft as [<$name:camel>]; }
@@ -69,6 +79,24 @@ macro_rules! def_field {
                     Self::from_repr_vartime(FtRepr(bytes)).unwrap()
                 }
             }
+
+            impl std::convert::From<i64> for Ft {
+                #[track_caller]
+                fn from(mut i: i64) -> Self {
+                    let u = i.abs_diff(0);
+                    let neg = i < 0;
+                    if neg {
+                        -Ft::from(u)
+                    } else {
+                        Ft::from(u)
+                    }
+                }
+            }
+
+            use std::ops::{AddAssign, MulAssign, SubAssign};
+            i64_impl! { AddAssign, add_assign, Ft }
+            i64_impl! { SubAssign, sub_assign, Ft }
+            i64_impl! { MulAssign, mul_assign, Ft }
 
             #[cfg(test)]
             mod test {

--- a/circ_fields/src/ff_field.rs
+++ b/circ_fields/src/ff_field.rs
@@ -9,10 +9,11 @@ macro_rules! def_field {
         paste! { pub use $name::FMOD_ARC as [<$name:upper _FMOD_ARC>]; }
         pub mod $name {
             #![allow(warnings, clippy::derive_hash_xor_eq)]
+            use datasize::DataSize;
             use ff_derive::PrimeField;
             use ff_derive_num::Num;
             use serde::{Deserialize, Serialize};
-            #[derive(PrimeField, Num, Deserialize, Serialize, Hash)]
+            #[derive(PrimeField, Num, Deserialize, Serialize, Hash, DataSize)]
             #[PrimeFieldModulus = $mod]
             #[PrimeFieldGenerator = $gen]
             #[PrimeFieldReprEndianness = "little"]

--- a/circ_fields/src/int_field.rs
+++ b/circ_fields/src/int_field.rs
@@ -1,6 +1,7 @@
 //! Integer-based fields for use in CirC
 // based on Alex's original FieldElem impl
 
+use datasize::DataSize;
 use paste::paste;
 use rug::{
     ops::{RemRounding, RemRoundingAssign},
@@ -11,8 +12,9 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 use std::sync::Arc;
 
-#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash, Serialize, Deserialize, DataSize)]
 pub struct IntField {
+    #[data_size(with = super::size::estimate_heap_size_integer)]
     pub(crate) i: Integer,
     m: Arc<Integer>,
 }

--- a/circ_fields/src/int_field.rs
+++ b/circ_fields/src/int_field.rs
@@ -147,6 +147,15 @@ macro_rules! arith_impl {
                 }
             }
         }
+
+        paste! {
+            impl [<$Trait Assign>]<i64> for IntField {
+                fn [<$fn _assign>](&mut self, other: i64) {
+                    self.i.[<$fn _assign>](&other);
+                    self.i.rem_floor_assign(&*self.m);
+                }
+            }
+        }
     };
 }
 

--- a/circ_fields/src/lib.rs
+++ b/circ_fields/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod ff_field;
 mod int_field;
+pub mod size;
 
 /// Exports for moduli defined in this crate, as ARCs
 pub mod moduli {
@@ -16,6 +17,7 @@ use ff_field::{F_BLS12381_FMOD, F_BN254_FMOD};
 use ff_field::{F_BLS12381_FMOD_ARC, F_BN254_FMOD_ARC};
 use int_field::IntField;
 
+use datasize::DataSize;
 use ff::Field;
 use paste::paste;
 use rug::Integer;
@@ -27,7 +29,7 @@ use std::sync::Arc;
 // TODO: rework this using macros?
 
 /// Field element type
-#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize, Deserialize, DataSize)]
 pub enum FieldT {
     /// BLS12-381 scalar field as `ff`
     FBls12381,
@@ -134,7 +136,7 @@ impl FieldT {
 }
 
 /// Field element value
-#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize, Deserialize, DataSize)]
 pub enum FieldV {
     /// BLS12-381 scalar field element as `ff`
     FBls12381(FBls12381),

--- a/circ_fields/src/lib.rs
+++ b/circ_fields/src/lib.rs
@@ -344,7 +344,9 @@ impl FieldV {
 impl Clone for FieldV {
     #[inline]
     fn clone(&self) -> Self {
-        self.either_ref().map(|i| i.into()).unwrap_or_else(|full| Self::from(full.clone()))
+        self.either_ref()
+            .map(|i| i.into())
+            .unwrap_or_else(|full| Self::from(full.clone()))
     }
 }
 
@@ -625,7 +627,9 @@ impl FieldV {
     /// Raise this element to a power.
     #[inline]
     pub fn pow(&self, u: u64) -> Self {
-        if !self.is_full() && (self.inline().signed_bits() as u64).saturating_mul(u) < 64 - N_TAG_BITS as u64 {
+        if !self.is_full()
+            && (self.inline().signed_bits() as u64).saturating_mul(u) < 64 - N_TAG_BITS as u64
+        {
             let InlineFieldV(i, t) = self.inline();
             let i = i.pow(u as u32);
             assert!(InlineFieldV::i64_in_range(i));

--- a/circ_fields/src/lib.rs
+++ b/circ_fields/src/lib.rs
@@ -83,6 +83,15 @@ impl FieldT {
         }
     }
 
+    /// If this field has an inline tag, get it.
+    fn inline_tag(&self) -> Option<InlineFieldTag> {
+        match self {
+            FieldT::FBls12381 => Some(InlineFieldTag::Bls12381),
+            FieldT::FBn254 => Some(InlineFieldTag::Bn254),
+            FieldT::IntField(_) => None,
+        }
+    }
+
     /// Field modulus
     #[inline]
     pub fn modulus(&self) -> &Integer {
@@ -107,9 +116,9 @@ impl FieldT {
     #[inline]
     pub fn default_value(&self) -> FieldV {
         match self {
-            Self::FBls12381 => FieldV::FBls12381(Default::default()),
-            Self::FBn254 => FieldV::FBn254(Default::default()),
-            Self::IntField(m) => FieldV::IntField(IntField::new(Integer::from(0), m.clone())),
+            Self::FBls12381 => FieldV::from(InlineFieldV(0, InlineFieldTag::Bls12381)),
+            Self::FBn254 => FieldV::from(InlineFieldV(0, InlineFieldTag::Bn254)),
+            Self::IntField(_) => self.new_v(0),
         }
     }
 
@@ -131,13 +140,254 @@ impl FieldT {
     where
         Integer: From<I>,
     {
+        FieldV::new_ty_long(i, self.clone())
+    }
+
+    /// New value of this type
+    #[inline]
+    pub fn new_v_prim<I>(&self, i: I) -> FieldV
+    where
+        i64: From<I>,
+    {
         FieldV::new_ty(i, self.clone())
     }
 }
 
 /// Field element value
+#[derive(Serialize, Deserialize)]
+#[serde(into = "FullFieldV", from = "FullFieldV")]
+pub struct FieldV(i64);
+
+/// Number of bits in [FieldV] used for the tag.
+const N_TAG_BITS: u8 = 2;
+/// Number of bits in [FieldV] used for the tag.
+const N_TAG_BITS_I64: i64 = N_TAG_BITS as i64;
+/// Mask that selects the tag bits in a [FieldV].
+const TAG_BITS_MASK: i64 = (1 << N_TAG_BITS_I64) - 1;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum FieldTag {
+    FullField,
+    InlineBls12381,
+    InlineBn254,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum InlineFieldTag {
+    Bls12381,
+    Bn254,
+}
+
+impl From<u8> for FieldTag {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => FieldTag::FullField,
+            1 => FieldTag::InlineBls12381,
+            2 => FieldTag::InlineBn254,
+            _ => panic!("Invalid field tag {}", value),
+        }
+    }
+}
+
+impl From<InlineFieldTag> for FieldTag {
+    fn from(value: InlineFieldTag) -> Self {
+        match value {
+            InlineFieldTag::Bls12381 => FieldTag::InlineBls12381,
+            InlineFieldTag::Bn254 => FieldTag::InlineBn254,
+        }
+    }
+}
+
+impl From<FieldTag> for InlineFieldTag {
+    fn from(value: FieldTag) -> Self {
+        match value {
+            FieldTag::InlineBls12381 => InlineFieldTag::Bls12381,
+            FieldTag::InlineBn254 => InlineFieldTag::Bn254,
+            FieldTag::FullField => panic!("Tag {:?} is not inline", value),
+        }
+    }
+}
+
+impl FieldTag {
+    const fn u8(&self) -> u8 {
+        match self {
+            FieldTag::FullField => 0,
+            FieldTag::InlineBls12381 => 1,
+            FieldTag::InlineBn254 => 2,
+        }
+    }
+}
+
+impl InlineFieldTag {
+    fn ty(&self) -> FieldT {
+        match self {
+            InlineFieldTag::Bls12381 => FieldT::FBls12381,
+            InlineFieldTag::Bn254 => FieldT::FBn254,
+        }
+    }
+    fn modulus(&self) -> &'static Integer {
+        match self {
+            InlineFieldTag::Bls12381 => &F_BLS12381_FMOD,
+            InlineFieldTag::Bn254 => &F_BN254_FMOD,
+        }
+    }
+    fn matches(&self, v: &FullFieldV) -> bool {
+        match (self, v) {
+            (InlineFieldTag::Bls12381, FullFieldV::FBls12381(_)) => true,
+            (InlineFieldTag::Bn254, FullFieldV::FBn254(_)) => true,
+            _ => false,
+        }
+    }
+    #[track_caller]
+    fn assert_matches(&self, v: &FullFieldV) {
+        assert!(self.matches(v), "Field {:?} does not match {:?}", self, v);
+    }
+}
+
+struct InlineFieldV(i64, InlineFieldTag);
+
+impl InlineFieldV {
+    fn i64_in_range(i: i64) -> bool {
+        ((i << N_TAG_BITS_I64) >> N_TAG_BITS_I64) == i
+    }
+    fn signed_bits(&self) -> u32 {
+        if self.0 < 0 {
+            65 - self.0.leading_ones()
+        } else {
+            65 - self.0.leading_zeros()
+        }
+    }
+    fn repr_as_i64(&self) -> i64 {
+        debug_assert!(InlineFieldV::i64_in_range(self.0));
+        self.0 << N_TAG_BITS_I64 | FieldTag::from(self.1).u8() as i64
+    }
+}
+
+impl From<InlineFieldV> for FieldV {
+    fn from(v: InlineFieldV) -> Self {
+        FieldV(v.repr_as_i64())
+    }
+}
+impl From<FullFieldV> for FieldV {
+    fn from(f: FullFieldV) -> Self {
+        let this = Self(Box::into_raw(Box::new(f)) as i64);
+        assert!(this.is_full());
+        this
+    }
+}
+impl From<FieldV> for FullFieldV {
+    fn from(mut f: FieldV) -> Self {
+        if f.is_full() {
+            f.take_full()
+        } else {
+            FullFieldV::from(f.inline())
+        }
+    }
+}
+
+impl FieldV {
+    fn tag(&self) -> FieldTag {
+        FieldTag::from((self.0 & TAG_BITS_MASK) as u8)
+    }
+    fn inline_i64(&self) -> i64 {
+        debug_assert_ne!(self.tag(), FieldTag::FullField);
+        self.0 >> N_TAG_BITS_I64
+    }
+    fn full_mut(&mut self) -> &mut FullFieldV {
+        assert!(self.is_full());
+        let ptr: *mut FullFieldV = self.0 as *mut _;
+        unsafe { &mut *ptr }
+    }
+    fn full_ref(&self) -> &FullFieldV {
+        assert!(self.is_full());
+        let ptr: *const FullFieldV = self.0 as *const _;
+        unsafe { &*ptr }
+    }
+    fn full_cow(&self) -> std::borrow::Cow<FullFieldV> {
+        if self.is_full() {
+            std::borrow::Cow::Borrowed(self.full_ref())
+        } else {
+            std::borrow::Cow::Owned(FullFieldV::from(self.inline()))
+        }
+    }
+    fn take_full(&mut self) -> FullFieldV {
+        assert!(self.is_full());
+        unsafe {
+            let ptr: *mut FullFieldV = self.0 as *mut FullFieldV;
+            let box_ = Box::from_raw(ptr);
+            self.0 = InlineFieldV(0, InlineFieldTag::Bls12381).repr_as_i64();
+            *box_
+        }
+    }
+    fn is_full(&self) -> bool {
+        self.tag() == FieldTag::FullField
+    }
+    fn inline(&self) -> InlineFieldV {
+        debug_assert!(!self.is_full());
+        InlineFieldV(self.inline_i64(), self.tag().into())
+    }
+    fn promote(&mut self) -> &mut FullFieldV {
+        if !self.is_full() {
+            *self = Self::from(FullFieldV::from(self.inline()));
+        }
+        self.full_mut()
+    }
+    fn either_ref(&self) -> Result<InlineFieldV, &FullFieldV> {
+        if self.is_full() {
+            Err(self.full_ref())
+        } else {
+            Ok(self.inline())
+        }
+    }
+}
+
+impl Clone for FieldV {
+    #[inline]
+    fn clone(&self) -> Self {
+        self.either_ref().map(|i| i.into()).unwrap_or_else(|full| Self::from(full.clone()))
+    }
+}
+
+impl PartialOrd for FieldV {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for FieldV {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.full_cow().cmp(&other.full_cow())
+    }
+}
+
+impl PartialEq for FieldV {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.full_cow().eq(&other.full_cow())
+    }
+}
+
+impl Eq for FieldV {}
+
+impl std::hash::Hash for FieldV {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.full_cow().hash(state)
+    }
+}
+
+impl std::ops::Drop for FieldV {
+    fn drop(&mut self) {
+        if self.is_full() {
+            std::mem::drop(self.take_full())
+        }
+    }
+}
+
+/// Field element value
 #[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize, Deserialize, DataSize)]
-pub enum FieldV {
+pub enum FullFieldV {
     /// BLS12-381 scalar field element as `ff`
     FBls12381(FBls12381),
     /// BN-254 scalar field element as `ff`
@@ -146,14 +396,57 @@ pub enum FieldV {
     IntField(IntField),
 }
 
+impl From<InlineFieldV> for FullFieldV {
+    fn from(value: InlineFieldV) -> Self {
+        match value.1 {
+            InlineFieldTag::Bls12381 => FullFieldV::FBls12381(value.0.into()),
+            InlineFieldTag::Bn254 => FullFieldV::FBn254(value.0.into()),
+        }
+    }
+}
+
+impl FullFieldV {
+    /// Type of this value
+    #[inline]
+    fn ty(&self) -> FieldT {
+        match self {
+            FullFieldV::FBls12381(_) => FieldT::FBls12381,
+            FullFieldV::FBn254(_) => FieldT::FBn254,
+            FullFieldV::IntField(i) => FieldT::IntField(i.modulus_arc()),
+        }
+    }
+
+    /// Raise this element to a power.
+    #[inline]
+    fn pow(&self, u: u64) -> Self {
+        match self {
+            FullFieldV::FBls12381(f) => FullFieldV::FBls12381(f.pow_vartime(&[u])),
+            FullFieldV::FBn254(f) => FullFieldV::FBn254(f.pow_vartime(&[u])),
+            FullFieldV::IntField(i) => FullFieldV::IntField(IntField::new(
+                i.i.clone().pow_mod(&Integer::from(u), i.modulus()).unwrap(),
+                i.modulus_arc(),
+            )),
+        }
+    }
+
+    /// Get this field element as a signed integer. No particular cut-off is guaranteed.
+    #[inline]
+    fn signed_int(&self) -> Integer {
+        let mut i: Integer = self.into();
+        if i.significant_bits() >= self.ty().modulus().significant_bits() - 1 {
+            i -= self.ty().modulus();
+        }
+        i
+    }
+}
+
 impl FieldV {
     /// Type of this value
     #[inline]
     pub fn ty(&self) -> FieldT {
-        match self {
-            Self::FBls12381(_) => FieldT::FBls12381,
-            Self::FBn254(_) => FieldT::FBn254,
-            Self::IntField(i) => FieldT::IntField(i.modulus_arc()),
+        match self.either_ref() {
+            Ok(InlineFieldV(_, t)) => t.ty(),
+            Err(i) => i.ty(),
         }
     }
 
@@ -167,14 +460,14 @@ impl FieldV {
     where
         Integer: From<I>,
     {
-        Self::new_ty(i, FieldT::from(m))
+        Self::new_ty_long(i, FieldT::from(m))
     }
 
     /// Check that a value is well formed
     #[track_caller]
     #[inline]
     pub fn check(&self, loc: &str) {
-        if let Self::IntField(m) = self {
+        if let Err(FullFieldV::IntField(m)) = self.either_ref() {
             m.check(loc);
         }
     }
@@ -182,10 +475,11 @@ impl FieldV {
     /// Field modulus as `&rug::Integer`
     #[inline]
     pub fn modulus(&self) -> &Integer {
-        match self {
-            Self::FBls12381(_) => &F_BLS12381_FMOD,
-            Self::FBn254(_) => &F_BN254_FMOD,
-            Self::IntField(i) => i.modulus(),
+        match self.either_ref() {
+            Ok(InlineFieldV(_, t)) => t.modulus(),
+            Err(FullFieldV::FBls12381(_)) => &F_BLS12381_FMOD,
+            Err(FullFieldV::FBn254(_)) => &F_BN254_FMOD,
+            Err(FullFieldV::IntField(i)) => i.modulus(),
         }
     }
 
@@ -193,10 +487,10 @@ impl FieldV {
     #[track_caller]
     #[inline]
     pub fn recip_ref(&self) -> Self {
-        match self {
-            Self::FBls12381(pf) => Self::FBls12381(pf.invert().unwrap()),
-            Self::FBn254(pf) => Self::FBn254(pf.invert().unwrap()),
-            Self::IntField(i) => Self::IntField(i.clone().recip()),
+        match &*self.full_cow() {
+            FullFieldV::FBls12381(pf) => Self::from(FullFieldV::FBls12381(pf.invert().unwrap())),
+            FullFieldV::FBn254(pf) => Self::from(FullFieldV::FBn254(pf.invert().unwrap())),
+            FullFieldV::IntField(i) => Self::from(FullFieldV::IntField(i.clone().recip())),
         }
     }
 
@@ -204,10 +498,10 @@ impl FieldV {
     #[track_caller]
     #[inline]
     pub fn recip(self) -> Self {
-        match self {
-            Self::FBls12381(pf) => Self::FBls12381(pf.invert().unwrap()),
-            Self::FBn254(pf) => Self::FBn254(pf.invert().unwrap()),
-            Self::IntField(i) => Self::IntField(i.recip()),
+        match &*self.full_cow() {
+            FullFieldV::FBls12381(pf) => Self::from(FullFieldV::FBls12381(pf.invert().unwrap())),
+            FullFieldV::FBn254(pf) => Self::from(FullFieldV::FBn254(pf.invert().unwrap())),
+            FullFieldV::IntField(i) => Self::from(FullFieldV::IntField(i.clone().recip())),
         }
     }
 
@@ -220,10 +514,11 @@ impl FieldV {
     /// Test if value is zero
     #[inline]
     pub fn is_zero(&self) -> bool {
-        match self {
-            Self::FBls12381(pf) => bool::from(pf.is_zero()),
-            Self::FBn254(pf) => bool::from(pf.is_zero()),
-            Self::IntField(i) => i.is_zero(),
+        match self.either_ref() {
+            Ok(InlineFieldV(i, _)) => i == 0,
+            Err(FullFieldV::FBls12381(pf)) => bool::from(pf.is_zero()),
+            Err(FullFieldV::FBn254(pf)) => bool::from(pf.is_zero()),
+            Err(FullFieldV::IntField(i)) => i.is_zero(),
         }
     }
 
@@ -231,37 +526,67 @@ impl FieldV {
     #[inline]
     pub fn is_one(&self) -> bool {
         use num_traits::One;
-        match self {
-            Self::FBls12381(pf) => pf.is_one(),
-            Self::FBn254(pf) => pf.is_one(),
-            Self::IntField(i) => i.i == 1,
+        match self.either_ref() {
+            Ok(InlineFieldV(i, _)) => i == 1,
+            Err(FullFieldV::FBls12381(pf)) => bool::from(pf.is_one()),
+            Err(FullFieldV::FBn254(pf)) => bool::from(pf.is_one()),
+            Err(FullFieldV::IntField(i)) => i.i == 1,
         }
+    }
+
+    #[inline]
+    fn new_ty_long<I>(i: I, ty: FieldT) -> Self
+    where
+        Integer: From<I>,
+    {
+        // TODO: relax interface.
+        let i = Integer::from(i);
+        if i.signed_bits() < 64 - N_TAG_BITS as u32 {
+            if let Some(t) = ty.inline_tag() {
+                return Self::from(InlineFieldV(i.to_i64_wrapping(), t));
+            }
+        }
+        Self::from(match ty {
+            FieldT::FBls12381 => FullFieldV::FBls12381(FBls12381::from(i)),
+            FieldT::FBn254 => FullFieldV::FBn254(FBn254::from(i)),
+            FieldT::IntField(m) => FullFieldV::IntField(IntField::new(i, m)),
+        })
     }
 
     #[inline]
     fn new_ty<I>(i: I, ty: FieldT) -> Self
     where
-        Integer: From<I>,
+        i64: From<I>,
     {
-        let i = Integer::from(i);
-        match ty {
-            FieldT::FBls12381 => Self::FBls12381(FBls12381::from(i)),
-            FieldT::FBn254 => Self::FBn254(FBn254::from(i)),
-            FieldT::IntField(m) => Self::IntField(IntField::new(i, m)),
+        let i: i64 = i.into();
+        let bits = if i < 0 {
+            65 - i.leading_ones()
+        } else {
+            65 - i.leading_zeros()
+        };
+        if bits < 64 - N_TAG_BITS as u32 {
+            if let Some(t) = ty.inline_tag() {
+                return Self::from(InlineFieldV(i, t));
+            }
         }
+        Self::from(match ty {
+            FieldT::FBls12381 => FullFieldV::FBls12381(FBls12381::from(i)),
+            FieldT::FBn254 => FullFieldV::FBn254(FBn254::from(i)),
+            FieldT::IntField(m) => FullFieldV::IntField(IntField::new(Integer::from(i), m)),
+        })
     }
 
     fn random(ty: FieldT, mut rng: impl rand::RngCore) -> Self {
-        match ty {
-            FieldT::FBls12381 => Self::FBls12381(FBls12381::random(rng)),
-            FieldT::FBn254 => Self::FBn254(FBn254::random(rng)),
+        Self::from(match ty {
+            FieldT::FBls12381 => FullFieldV::FBls12381(FBls12381::random(rng)),
+            FieldT::FBn254 => FullFieldV::FBn254(FBn254::random(rng)),
             FieldT::IntField(m) => {
                 let mut rug_rng = rug::rand::RandState::new_mersenne_twister();
                 rug_rng.seed(&Integer::from(rng.next_u64()));
                 let i = Integer::from(m.random_below_ref(&mut rug_rng));
-                Self::IntField(IntField::new(i, m))
+                FullFieldV::IntField(IntField::new(i, m))
             }
-        }
+        })
     }
 
     /// Convert to a different FieldT --- will fail if moduli are not the same!
@@ -284,11 +609,7 @@ impl FieldV {
     /// Get this field element as an SMT-LIB string.
     #[inline]
     pub fn as_smtlib(&self) -> String {
-        match self {
-            Self::FBls12381(pf) => format!("#f{}m{}", Integer::from(pf), &*F_BLS12381_FMOD),
-            Self::FBn254(pf) => format!("#f{}m{}", Integer::from(pf), &*F_BN254_FMOD),
-            Self::IntField(i) => format!("{}", i),
-        }
+        format!("#f{}m{}", self.signed_int(), self.ty().modulus())
     }
 
     /// Get this field element as a signed integer. No particular cut-off is guaranteed.
@@ -304,13 +625,13 @@ impl FieldV {
     /// Raise this element to a power.
     #[inline]
     pub fn pow(&self, u: u64) -> Self {
-        match self {
-            FieldV::FBls12381(f) => FieldV::FBls12381(f.pow_vartime(&[u])),
-            FieldV::FBn254(f) => FieldV::FBn254(f.pow_vartime(&[u])),
-            FieldV::IntField(i) => FieldV::IntField(IntField::new(
-                i.i.clone().pow_mod(&Integer::from(u), i.modulus()).unwrap(),
-                i.modulus_arc(),
-            )),
+        if !self.is_full() && (self.inline().signed_bits() as u64).saturating_mul(u) < 64 - N_TAG_BITS as u64 {
+            let InlineFieldV(i, t) = self.inline();
+            let i = i.pow(u as u32);
+            assert!(InlineFieldV::i64_in_range(i));
+            Self::from(InlineFieldV(i, t))
+        } else {
+            self.full_cow().pow(u).into()
         }
     }
 }
@@ -324,6 +645,27 @@ impl Display for FieldV {
 impl Debug for FieldV {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{} (in {})", self.signed_int(), self.ty())
+    }
+}
+
+impl Debug for FullFieldV {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{} (in {})", self.signed_int(), self.ty())
+    }
+}
+
+impl DataSize for FieldV {
+    const IS_DYNAMIC: bool = true;
+
+    const STATIC_HEAP_SIZE: usize = 0;
+
+    #[inline]
+    fn estimate_heap_size(&self) -> usize {
+        if self.is_full() {
+            self.full_ref().estimate_heap_size() + std::mem::size_of::<FullFieldV>()
+        } else {
+            0
+        }
     }
 }
 
@@ -346,8 +688,14 @@ macro_rules! arith_impl {
                 }
             }
 
-            impl [<$Trait Assign>]<&FieldV> for FieldV {
-                fn [<$fn _assign>](&mut self, other: &FieldV) {
+            impl [<$Trait Assign>]<FieldV> for FieldV {
+                fn [<$fn _assign>](&mut self, other: FieldV) {
+                    self.[<$fn _assign>](&other);
+                }
+            }
+
+            impl [<$Trait Assign>]<&FullFieldV> for FullFieldV {
+                fn [<$fn _assign>](&mut self, other: &FullFieldV) {
                     match (self, other) {
                         (Self::FBls12381(f1), Self::FBls12381(f2)) => f1.[<$fn _assign>](f2),
                         (Self::FBn254(f1), Self::FBn254(f2)) => f1.[<$fn _assign>](f2),
@@ -357,9 +705,31 @@ macro_rules! arith_impl {
                 }
             }
 
-            impl [<$Trait Assign>]<FieldV> for FieldV {
-                fn [<$fn _assign>](&mut self, other: FieldV) {
-                    self.[<$fn _assign>](&other);
+            impl [<$Trait Assign>]<i64> for FullFieldV {
+                fn [<$fn _assign>](&mut self, other: i64) {
+                    match self {
+                        Self::FBls12381(f1) => f1.[<$fn _assign>](other),
+                        Self::FBn254(f1) => f1.[<$fn _assign>](other),
+                        Self::IntField(f1) => f1.[<$fn _assign>](other),
+                    }
+                }
+            }
+
+            impl [<$Trait Assign>]<InlineFieldV> for FullFieldV {
+                fn [<$fn _assign>](&mut self, InlineFieldV(i, t): InlineFieldV) {
+                    t.assert_matches(self);
+                    self.[<$fn _assign>](i)
+                }
+            }
+
+            impl [<$Trait Assign>]<&FieldV> for FieldV {
+                fn [<$fn _assign>](&mut self, other: &FieldV) {
+                    match (self.is_full(), other.is_full()) {
+                        (false, false) => *self = self.inline().$fn(other.inline()),
+                        (false, true) => self.promote().[<$fn _assign>](other.full_ref()),
+                        (true, false) => self.full_mut().[<$fn _assign>](other.inline()),
+                        (true, true) => self.full_mut().[<$fn _assign>](other.full_ref()),
+                    }
                 }
             }
         }
@@ -370,56 +740,142 @@ arith_impl!(Add, add);
 arith_impl!(Mul, mul);
 arith_impl!(Sub, sub);
 
+impl Add<InlineFieldV> for InlineFieldV {
+    type Output = FieldV;
+
+    fn add(self, rhs: InlineFieldV) -> Self::Output {
+        assert_eq!(self.1, rhs.1);
+        let x = self.0.add(rhs.0);
+        if InlineFieldV::i64_in_range(x) {
+            FieldV::from(InlineFieldV(x, self.1))
+        } else {
+            let mut this = FullFieldV::from(self);
+            this.add_assign(rhs.0);
+            FieldV::from(this)
+        }
+    }
+}
+
+impl Sub<InlineFieldV> for InlineFieldV {
+    type Output = FieldV;
+
+    fn sub(self, rhs: InlineFieldV) -> Self::Output {
+        assert_eq!(self.1, rhs.1);
+        let x = self.0.sub(rhs.0);
+        if InlineFieldV::i64_in_range(x) {
+            FieldV::from(InlineFieldV(x, self.1))
+        } else {
+            let mut this = FullFieldV::from(self);
+            this.sub_assign(rhs.0);
+            FieldV::from(this)
+        }
+    }
+}
+
+impl Mul<InlineFieldV> for InlineFieldV {
+    type Output = FieldV;
+
+    fn mul(self, rhs: InlineFieldV) -> Self::Output {
+        assert_eq!(self.1, rhs.1);
+        let x = self.0.checked_mul(rhs.0);
+        if let Some(x) = x {
+            if InlineFieldV::i64_in_range(x) {
+                return FieldV::from(InlineFieldV(x, self.1));
+            }
+        }
+        let mut this = FullFieldV::from(self);
+        this.mul_assign(rhs.0);
+        FieldV::from(this)
+    }
+}
+
 impl Neg for FieldV {
     type Output = Self;
-    fn neg(self) -> Self {
-        match self {
-            Self::FBls12381(pf) => Self::FBls12381(pf.neg()),
-            Self::FBn254(pf) => Self::FBn254(pf.neg()),
-            Self::IntField(i) => Self::IntField(i.neg()),
+    fn neg(mut self) -> Self {
+        if self.is_full() {
+            match self.full_mut() {
+                FullFieldV::FBls12381(pf) => Self::from(FullFieldV::FBls12381(pf.clone().neg())),
+                FullFieldV::FBn254(pf) => Self::from(FullFieldV::FBn254(pf.clone().neg())),
+                FullFieldV::IntField(i) => Self::from(FullFieldV::IntField(i.clone().neg())),
+            }
+        } else {
+            let InlineFieldV(i, t) = self.inline();
+            let ni = -i;
+            if InlineFieldV::i64_in_range(ni) {
+                Self::from(InlineFieldV(ni, t))
+            } else {
+                self.promote();
+                self.neg()
+            }
         }
     }
 }
 
 #[allow(clippy::from_over_into)]
-impl Into<FieldV> for FBls12381 {
-    fn into(self) -> FieldV {
-        FieldV::FBls12381(self)
+impl Into<FullFieldV> for FBls12381 {
+    fn into(self) -> FullFieldV {
+        FullFieldV::FBls12381(self)
     }
 }
 
 #[allow(clippy::from_over_into)]
-impl Into<FieldV> for FBn254 {
-    fn into(self) -> FieldV {
-        FieldV::FBn254(self)
+impl Into<FullFieldV> for FBn254 {
+    fn into(self) -> FullFieldV {
+        FullFieldV::FBn254(self)
     }
 }
 
 #[allow(clippy::from_over_into)]
-impl Into<FieldV> for IntField {
-    fn into(self) -> FieldV {
-        FieldV::IntField(self)
+impl Into<FullFieldV> for IntField {
+    fn into(self) -> FullFieldV {
+        FullFieldV::IntField(self)
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<Integer> for FullFieldV {
+    fn into(self) -> Integer {
+        match self {
+            FullFieldV::FBls12381(f) => Integer::from(&f),
+            FullFieldV::FBn254(f) => Integer::from(&f),
+            FullFieldV::IntField(i) => i.i,
+        }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<Integer> for &FullFieldV {
+    fn into(self) -> Integer {
+        match self {
+            FullFieldV::FBls12381(f) => Integer::from(f),
+            FullFieldV::FBn254(f) => Integer::from(f),
+            FullFieldV::IntField(i) => i.i.clone(),
+        }
     }
 }
 
 #[allow(clippy::from_over_into)]
 impl Into<Integer> for FieldV {
     fn into(self) -> Integer {
-        match self {
-            FieldV::FBls12381(f) => Integer::from(&f),
-            FieldV::FBn254(f) => Integer::from(&f),
-            FieldV::IntField(i) => i.i,
-        }
+        Into::into(&self)
     }
 }
 
 #[allow(clippy::from_over_into)]
 impl Into<Integer> for &FieldV {
     fn into(self) -> Integer {
-        match self {
-            FieldV::FBls12381(f) => Integer::from(f),
-            FieldV::FBn254(f) => Integer::from(f),
-            FieldV::IntField(i) => i.i.clone(),
+        if self.is_full() {
+            self.full_ref().into()
+        } else {
+            let i = self.inline().0;
+            if i < 0 {
+                Integer::from(i) + self.modulus()
+            } else {
+                Integer::from(i)
+            }
         }
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/circ_fields/src/lib.rs
+++ b/circ_fields/src/lib.rs
@@ -154,6 +154,17 @@ impl FieldT {
 }
 
 /// Field element value
+///
+/// ## Implementation Notes
+///
+/// The contents are either:
+/// * a pointer to an enum [FullFieldV] or
+/// * a i62 with a type-tag
+///
+/// The tag can be:
+/// * 00: pointer
+/// * 01, 10: different fields
+/// * 11: invalid (for now)
 #[derive(Serialize, Deserialize)]
 #[serde(into = "FullFieldV", from = "FullFieldV")]
 pub struct FieldV(i64);

--- a/circ_fields/src/size.rs
+++ b/circ_fields/src/size.rs
@@ -1,0 +1,9 @@
+//! Heap Size helpers for use with [datasize].
+
+use rug::Integer;
+
+/// Measure memory footprint of an integer
+pub fn estimate_heap_size_integer(i: &Integer) -> usize {
+    // a guess
+    i.capacity() / 8
+}

--- a/circ_fields/src/test.rs
+++ b/circ_fields/src/test.rs
@@ -1,0 +1,123 @@
+use super::*;
+use rand::thread_rng;
+use rand::Rng;
+use rug::ops::RemRounding;
+
+#[test]
+fn inline_signed_bits() {
+    assert_eq!(InlineFieldV(-2, InlineFieldTag::Bls12381).signed_bits(), 2);
+    assert_eq!(InlineFieldV(1, InlineFieldTag::Bls12381).signed_bits(), 2);
+    assert_eq!(
+        InlineFieldV(i64::MAX, InlineFieldTag::Bls12381).signed_bits(),
+        64
+    );
+    assert_eq!(
+        InlineFieldV(i64::MIN, InlineFieldTag::Bls12381).signed_bits(),
+        64
+    );
+    assert_eq!(
+        InlineFieldV(i64::MAX / 2, InlineFieldTag::Bls12381).signed_bits(),
+        63
+    );
+    assert_eq!(
+        InlineFieldV(i64::MIN / 2, InlineFieldTag::Bls12381).signed_bits(),
+        63
+    );
+    assert_eq!(
+        InlineFieldV(i64::MAX / 2 + 1, InlineFieldTag::Bls12381).signed_bits(),
+        64
+    );
+    assert_eq!(
+        InlineFieldV(i64::MIN / 2 - 1, InlineFieldTag::Bls12381).signed_bits(),
+        64
+    );
+}
+use rug::Integer;
+
+#[test]
+fn inline_signed_bits_randomized() {
+    let mut rng = thread_rng();
+    for _ in 0..1024 {
+        let i: i64 = rng.gen();
+        let n_bits = rng.gen_range(0..64);
+        let i = i % (1 << n_bits);
+        let big_i = Integer::from(i);
+        assert_eq!(
+            InlineFieldV(i, InlineFieldTag::Bls12381).signed_bits(),
+            big_i.signed_bits(),
+            "wrong answer on {:b}",
+            i
+        )
+    }
+}
+
+/// Samples a random integer with up to `max_bits` bits.
+///
+/// A number with `i` is chosen with probability proportional to `2^-i`.
+fn random_rug_int_exp(rng: &mut impl Rng, max_bits: u32) -> Integer {
+    let num_bits = rng.gen_range(1u32..max_bits);
+    let mut rug_rng = rug::rand::RandState::new_mersenne_twister();
+    rug_rng.seed(&Integer::from(rng.next_u64()));
+    Integer::from(Integer::random_bits(num_bits, &mut rug_rng))
+}
+
+/// Sample a [FieldT] that is:
+/// * Bls w/ p = 0.25
+/// * Bn w/ p = 0.25
+/// * An integer field otherwise
+///   * with a number of bits sampled uniformly between 1..max_bits
+fn sample_field_t(r: &mut impl Rng, max_bits: u32) -> FieldT {
+    if r.gen_bool(0.5) {
+        if r.gen_bool(0.5) {
+            FieldT::FBls12381
+        } else {
+            FieldT::FBn254
+        }
+    } else {
+        FieldT::IntField(Arc::new(random_rug_int_exp(r, max_bits).next_prime()))
+    }
+}
+
+/// Sample a [FieldV]. If `ty` is inlinable, the value will be inline with probability 0.5.
+fn sample_field_v(ty: &FieldT, r: &mut impl Rng) -> FieldV {
+    if let Some(t) = ty.inline_tag() {
+        if r.gen_bool(0.5) {
+            let num_bits = r.gen_range(0..62);
+            let i: i64 = r.gen();
+            return FieldV::from(InlineFieldV(i % (1 << num_bits as i64), t));
+        }
+    }
+    ty.new_v(random_rug_int_exp(r, ty.modulus().significant_bits()))
+}
+
+#[test]
+fn random() {
+    let mut rng = thread_rng();
+    for _ in 0..1024 {
+        let f = sample_field_t(&mut rng, 256);
+        let a = sample_field_v(&f, &mut rng);
+        let b = sample_field_v(&f, &mut rng);
+        let a_i = a.i();
+        let b_i = b.i();
+
+        // add
+        let c = a.clone() + &b;
+        let c_i = (a_i.clone() + &b_i).rem_floor(f.modulus());
+        assert_eq!(c.i(), c_i);
+
+        // sub
+        let c = a.clone() - &b;
+        let c_i = (a_i.clone() - &b_i).rem_floor(f.modulus());
+        assert_eq!(c.i(), c_i);
+
+        // mul
+        let c = a.clone() * &b;
+        let c_i = (a_i.clone() * &b_i).rem_floor(f.modulus());
+        assert_eq!(c.i(), c_i);
+
+        // neg
+        let c = -a.clone();
+        let c_i = (-a_i.clone()).rem_floor(f.modulus());
+        assert_eq!(c.i(), c_i);
+    }
+}


### PR DESCRIPTION
Reduces R1CS lowering memory usage by ~40% on a persistent memory benchmark.