### PR TITLE
convert array::store -> tuple::field

### DIFF
--- a/src/ir/opt/mem/lin.rs
+++ b/src/ir/opt/mem/lin.rs
@@ -69,15 +69,14 @@ impl RewritePass for Linearizer {
                         let idx_usize = extras::as_uint_constant(idx).unwrap().to_usize().unwrap();
                         Some(term![Op::Update(idx_usize); tup.clone(), val.clone()])
                     } else {
-                        let arr_idxs = (0..size).into_iter();
-                        let mut tulpe_entries= Vec::with_capacity(size);        
-                        for element in key_sort.elems_iter().take(size).zip(arr_idxs){
-                            tulpe_entries.push(
-                                term![Op::Ite; term![Op::Eq; idx.clone(), element.0], 
+                        let mut tuple_entries = Vec::with_capacity(size);        
+                        for (term, tup_idx) in key_sort.elems_iter().take(size).zip(0..size){
+                            tuple_entries.push(
+                                term![Op::Ite; term![Op::Eq; idx.clone(), term], 
                                     val.clone(),
-                                    term![Op::Field(element.1);tup.clone()]]);
+                                    term![Op::Field(tup_idx);tup.clone()]]);
                         }
-                        Some(term(Op::Tuple, tulpe_entries))
+                        Some(term(Op::Tuple, tuple_entries))
                     }
                 } else {
                     unreachable!()


### PR DESCRIPTION
The linear scan converts `store` operation on `arrays` into `ITE` over an updated tuple for every index. e.g `(store A I V)` -> `(ite (= I 0) ((update 0) T V) (ite (= I 1) ((update 1) T V) T)))` where `T` is the tuple that represents `A`.

Later, the tuple pass converts translate an ITE over a tuple of length `n` into `n` different non-tuple ITEs, causing a quadratic increase in term.

This fix will cause the linear scan to covert `store` into `field` operation over a `tuple` that prevents the later quadratic blow-up.  