### PR TITLE
r1cs: fix boolean majority

### DIFF
--- a/examples/ZoKrates/pf/maj.zok
+++ b/examples/ZoKrates/pf/maj.zok
@@ -1,0 +1,2 @@
+def main(u8 a, u8 b, u8 c) -> u8:
+    return (a & b) ^ (a & c) ^ (b & c)

--- a/examples/ZoKrates/pf/maj.zok.pin
+++ b/examples/ZoKrates/pf/maj.zok.pin
@@ -1,0 +1,7 @@
+(let (
+    (a #xFD)
+    (b #xC9)
+    (c #xD0)
+)
+    false
+)

--- a/examples/ZoKrates/pf/sha_rot.zok
+++ b/examples/ZoKrates/pf/sha_rot.zok
@@ -1,0 +1,3 @@
+from "hashes/sha256/shaRound" import rotr32
+def main(u32 x) -> u32:
+    return rotr32::<2>(x)

--- a/examples/ZoKrates/pf/sha_rot.zok.pin
+++ b/examples/ZoKrates/pf/sha_rot.zok.pin
@@ -1,0 +1,6 @@
+(let (
+    (x #xFDE77DBB)
+)
+    false
+)
+

--- a/examples/ZoKrates/pf/sha_temp1.zok
+++ b/examples/ZoKrates/pf/sha_temp1.zok
@@ -1,0 +1,4 @@
+from "hashes/sha256/shaRound" import temp1
+
+def main(u32 e, u32 f, u32 g, u32 h, u32 k, u32 w) -> u32:
+    return temp1(e, f, g, h, k, w)

--- a/examples/ZoKrates/pf/sha_temp1.zok.pin
+++ b/examples/ZoKrates/pf/sha_temp1.zok.pin
@@ -1,0 +1,10 @@
+(let (
+    (e #xFDE77DBB)
+    (f #xC902D1E1)
+    (g #xD0025545)
+    (h #xFE4A9A6B)
+    (k #xDA2B4E1D)
+    (w #xD9D48E49)
+)
+    false
+)

--- a/examples/ZoKrates/pf/sha_temp2.zok
+++ b/examples/ZoKrates/pf/sha_temp2.zok
@@ -1,0 +1,3 @@
+from "hashes/sha256/shaRound" import temp2
+def main(u32 a, u32 b, u32 c) -> u32:
+    return temp2(a, b, c)

--- a/examples/ZoKrates/pf/sha_temp2.zok.pin
+++ b/examples/ZoKrates/pf/sha_temp2.zok.pin
@@ -1,0 +1,7 @@
+(let (
+    (a #xFDE77DBB)
+    (b #xC902D1E1)
+    (c #xD0025545)
+)
+    false
+)

--- a/examples/ZoKrates/pf/test_sha256.zok
+++ b/examples/ZoKrates/pf/test_sha256.zok
@@ -1,0 +1,8 @@
+import "hashes/sha256/sha256"
+
+
+def main(private u32[1][16] padded_message) -> u32[8]:
+
+    u32[8] hash = sha256(padded_message)
+
+    return hash

--- a/examples/ZoKrates/pf/test_sha256.zok.pin
+++ b/examples/ZoKrates/pf/test_sha256.zok.pin
@@ -1,0 +1,40 @@
+(set_default_modulus 52435875175126190479447740508185965837690552500527637822603658699938581184513
+
+(let (
+
+(padded_message.0.0 #x01020304)
+
+(padded_message.0.1 #x80000000)
+
+(padded_message.0.2 #x00000000)
+
+(padded_message.0.3 #x00000000)
+
+(padded_message.0.4 #x00000000)
+
+(padded_message.0.5 #x00000000)
+
+(padded_message.0.6 #x00000000)
+
+(padded_message.0.7 #x00000000)
+
+(padded_message.0.8 #x00000000)
+
+(padded_message.0.9 #x00000000)
+
+(padded_message.0.10 #x00000000)
+
+(padded_message.0.11 #x00000000)
+
+(padded_message.0.12 #x00000000)
+
+(padded_message.0.13 #x00000000)
+
+(padded_message.0.14 #x00000000)
+
+(padded_message.0.15 #x00000020)
+
+
+) true; ignored
+
+))

--- a/scripts/zokrates_test.zsh
+++ b/scripts/zokrates_test.zsh
@@ -45,6 +45,17 @@ function pf_test {
     done
 }
 
+# Test setup + prove, given an example name (does not test verification)
+function pf_test_only_pf {
+    for proof_impl in mirage
+    do
+        ex_name=$1
+        $BIN examples/ZoKrates/pf/$ex_name.zok r1cs --action setup --proof-impl $proof_impl
+        $ZK_BIN --inputs examples/ZoKrates/pf/$ex_name.zok.pin --action prove --proof-impl $proof_impl
+        rm -rf P V pi
+    done
+}
+
 # Test prove workflow with --z-isolate-asserts, given an example name
 function pf_test_isolate {
     for proof_impl in groth16 mirage
@@ -71,6 +82,11 @@ r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/bool_128_to_
 r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/ecc/edwardsScalarMult.zok
 r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/hashes/mimc7/mimc7R20.zok
 r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/hashes/pedersen/512bit.zok
+
+pf_test_only_pf sha_temp1
+pf_test_only_pf sha_rot
+pf_test_only_pf maj
+pf_test_only_pf sha_temp2
 
 pf_test assert
 pf_test_isolate isolate_assert

--- a/scripts/zokrates_test.zsh
+++ b/scripts/zokrates_test.zsh
@@ -87,6 +87,7 @@ pf_test_only_pf sha_temp1
 pf_test_only_pf sha_rot
 pf_test_only_pf maj
 pf_test_only_pf sha_temp2
+#pf_test_only_pf test_sha256
 
 pf_test assert
 pf_test_isolate isolate_assert

--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -732,6 +732,7 @@ impl<'ast> ZGen<'ast> {
                         assertions.push(ret_eq);
                         term(AND, assertions)
                     };
+                    debug!("Assertion: {}", to_assert);
                     self.circ.borrow_mut().assert(to_assert);
                 }
                 Mode::Opt => {

--- a/src/target/r1cs/mod.rs
+++ b/src/target/r1cs/mod.rs
@@ -397,9 +397,9 @@ impl R1csFinal {
         let cv = self.eval(c, values);
         if (av.clone() * &bv) != cv {
             let mut vars: HashSet<Var> = Default::default();
-            vars.extend(a.monomials.iter().map(|(k, _)| k.clone()));
-            vars.extend(b.monomials.iter().map(|(k, _)| k.clone()));
-            vars.extend(c.monomials.iter().map(|(k, _)| k.clone()));
+            vars.extend(a.monomials.keys().copied());
+            vars.extend(b.monomials.keys().copied());
+            vars.extend(c.monomials.keys().copied());
             for (k, v) in values {
                 if vars.contains(k) {
                     eprintln!("  {} -> {}", self.names.get(k).unwrap(), v);
@@ -479,7 +479,14 @@ impl ProverData {
             // do a round of evaluation
             let value_vec = eval.eval_stage(std::mem::take(&mut inputs));
             for value in value_vec {
-                trace!("var {} : {}", self.r1cs.names.get(&self.r1cs.vars[var_values.len()]).unwrap(), value.as_pf());
+                trace!(
+                    "var {} : {}",
+                    self.r1cs
+                        .names
+                        .get(&self.r1cs.vars[var_values.len()])
+                        .unwrap(),
+                    value.as_pf()
+                );
                 var_values.insert(self.r1cs.vars[var_values.len()], value.as_pf().clone());
             }
             // fill the challenges with 1s

--- a/src/target/r1cs/mod.rs
+++ b/src/target/r1cs/mod.rs
@@ -396,6 +396,15 @@ impl R1csFinal {
         let bv = self.eval(b, values);
         let cv = self.eval(c, values);
         if (av.clone() * &bv) != cv {
+            let mut vars: HashSet<Var> = Default::default();
+            vars.extend(a.monomials.iter().map(|(k, _)| k.clone()));
+            vars.extend(b.monomials.iter().map(|(k, _)| k.clone()));
+            vars.extend(c.monomials.iter().map(|(k, _)| k.clone()));
+            for (k, v) in values {
+                if vars.contains(k) {
+                    eprintln!("  {} -> {}", self.names.get(k).unwrap(), v);
+                }
+            }
             panic!(
                 "Error! Bad constraint:\n    {} (value {})\n  * {} (value {})\n  = {} (value {})",
                 self.format_lc(a),
@@ -428,7 +437,7 @@ impl R1csFinal {
 
         s.push_str(&format_i(&a.constant));
         for (idx, coeff) in &a.monomials {
-            s.extend(format!(" {} {}", self.names.get(idx).unwrap(), format_i(coeff),).chars());
+            s.extend(format!(" {} {}", format_i(coeff), self.names.get(idx).unwrap()).chars());
         }
         s
     }
@@ -470,6 +479,7 @@ impl ProverData {
             // do a round of evaluation
             let value_vec = eval.eval_stage(std::mem::take(&mut inputs));
             for value in value_vec {
+                trace!("var {} : {}", self.r1cs.names.get(&self.r1cs.vars[var_values.len()]).unwrap(), value.as_pf());
                 var_values.insert(self.r1cs.vars[var_values.len()], value.as_pf().clone());
             }
             // fill the challenges with 1s

--- a/src/target/r1cs/trans.rs
+++ b/src/target/r1cs/trans.rs
@@ -10,7 +10,7 @@ use crate::target::r1cs::*;
 
 use circ_fields::FieldT;
 use circ_opt::FieldDivByZero;
-use log::debug;
+use log::{debug, trace};
 use rug::ops::Pow;
 use rug::Integer;
 
@@ -371,6 +371,7 @@ impl<'cfg> ToR1cs<'cfg> {
         if !self.used_vars.contains(var.as_var_name()) {
             return;
         }
+        debug!("Embed var: {}", var.op());
         self.profile_start_term(var.clone());
         let public = matches!(ty, VarType::Inst);
         match var.op() {
@@ -430,7 +431,7 @@ impl<'cfg> ToR1cs<'cfg> {
                         self.embed_bool(c);
                     }
                     Sort::BitVector(_) => {
-                        self.embed_bv_lit(c);
+                        self.embed_bv(c);
                     }
                     Sort::Field(_) => {
                         self.embed_pf(c);
@@ -528,7 +529,7 @@ impl<'cfg> ToR1cs<'cfg> {
                     //   where i = ab
                     // m = i + c(b + a - 2i)
                     let i = self.mul(a.clone(), b.clone());
-                    self.mul(c, b + &a - &(i.clone() * 2)) - &i
+                    self.mul(c, b + &a - &(i.clone() * 2)) + &i
                 }
                 Op::Not => {
                     let a = self.get_bool(&c.cs()[0]);
@@ -718,7 +719,7 @@ impl<'cfg> ToR1cs<'cfg> {
         (some_high_bit, shift_amt)
     }
 
-    fn embed_bv_lit(&mut self, bv: Term) {
+    fn embed_bv(&mut self, bv: Term) {
         //println!("Embed: {}", bv);
         //let bv2=  bv.clone();
         if let Sort::BitVector(n) = check(&bv) {
@@ -1455,5 +1456,47 @@ pub mod test {
         crate::ir::opt::tuple::eliminate_tuples(&mut cs);
         let r1cs = to_r1cs_mod17(cs);
         r1cs.check_all(&values);
+    }
+
+    fn add_test_instance(args: &[u64], res: u64, bits: usize) {
+        let sum: u64 = args.iter().sum::<u64>() & ((1 <<  bits) - 1);
+        assert_eq!(sum, res);
+        const_test(term![Op::Eq; term(BV_ADD, args.iter().map(|a| bv_lit(*a, bits)).collect()), bv_lit(res, bits)]);
+    }
+
+    #[test]
+    fn add_test() {
+        init();
+        add_test_instance(&[0b0, 0b0, 0b0, 0b0], 0b0, 1);
+        add_test_instance(&[0b1, 0b0, 0b0, 0b0], 0b1, 1);
+        add_test_instance(&[0b1, 0b1, 0b1, 0b0], 0b1, 1);
+        add_test_instance(&[0b1, 0b1, 0b1, 0b1], 0b0, 1);
+        add_test_instance(&[0b11, 0b11, 0b11, 0b11], 0b00, 2);
+        add_test_instance(&[0b11, 0b11, 0b11, 0b11, 0b11], 0b11, 2);
+    }
+
+    #[test]
+    fn concat_test() {
+        init();
+        const_test(term![
+            Op::Eq;
+            term![BV_CONCAT; bv_lit(0b10,2), bv_lit(0b01,2)],
+            bv_lit(0b1001, 4)
+        ]);
+        const_test(term![
+            Op::Eq;
+            term![BV_CONCAT; bv_lit(0b11,2), bv_lit(0b01,2)],
+            bv_lit(0b1101, 4)
+        ]);
+    }
+
+    #[test]
+    fn maj_test() {
+        init();
+        const_test(term![
+            Op::Eq;
+            term![Op::BoolMaj; bool_lit(true), bool_lit(true), bool_lit(true)],
+            bool_lit(true)
+        ]);
     }
 }

--- a/src/target/r1cs/trans.rs
+++ b/src/target/r1cs/trans.rs
@@ -1459,9 +1459,11 @@ pub mod test {
     }
 
     fn add_test_instance(args: &[u64], res: u64, bits: usize) {
-        let sum: u64 = args.iter().sum::<u64>() & ((1 <<  bits) - 1);
+        let sum: u64 = args.iter().sum::<u64>() & ((1 << bits) - 1);
         assert_eq!(sum, res);
-        const_test(term![Op::Eq; term(BV_ADD, args.iter().map(|a| bv_lit(*a, bits)).collect()), bv_lit(res, bits)]);
+        const_test(
+            term![Op::Eq; term(BV_ADD, args.iter().map(|a| bv_lit(*a, bits)).collect()), bv_lit(res, bits)],
+        );
     }
 
     #[test]

--- a/src/target/r1cs/wit_comp.rs
+++ b/src/target/r1cs/wit_comp.rs
@@ -147,6 +147,13 @@ impl<'a> StagedWitCompEvaluator<'a> {
         debug_assert!(self.stages_evaluated < self.comp.stages.len());
         let stage = &self.comp.stages[self.stages_evaluated];
         let num_outputs = stage.num_outputs;
+        for (k, v) in &inputs {
+            trace!(
+                "Input {}: {}",
+                k,
+                v,
+            );
+        }
         self.variable_values.extend(inputs);
         if num_outputs > 0 {
             let max_step = (0..num_outputs)

--- a/src/target/r1cs/wit_comp.rs
+++ b/src/target/r1cs/wit_comp.rs
@@ -148,11 +148,7 @@ impl<'a> StagedWitCompEvaluator<'a> {
         let stage = &self.comp.stages[self.stages_evaluated];
         let num_outputs = stage.num_outputs;
         for (k, v) in &inputs {
-            trace!(
-                "Input {}: {}",
-                k,
-                v,
-            );
+            trace!("Input {}: {}", k, v,);
         }
         self.variable_values.extend(inputs);
         if num_outputs > 0 {


### PR DESCRIPTION
for m = majority(a,b,c),
we were lowering

    (-ab + bc + ac - 2abc)

instead of

    (ab + bc + ac - 2abc)

Whoops! This is a functional correctness bug: we were lowering soundly and completely, for the wrong specification.

Credit to Anna for raising the issue!