### PR TITLE
Optimize GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ name = "circ_hc"
 version = "0.1.0"
 dependencies = [
  "fxhash",
+ "log",
  "lru",
 ]
 

--- a/circ_hc/Cargo.toml
+++ b/circ_hc/Cargo.toml
@@ -13,6 +13,7 @@ default = ["hashconsing", "lru", "raw", "rc"]
 [dependencies]
 fxhash = "0.2.1"
 hashconsing = { git = "https://github.com/alex-ozdemir/hashconsing.git", branch = "phash", optional = true }
+log = "0.4"
 lru = { version = "0.7.2", optional = true }
 
 [dev-dependencies]

--- a/circ_hc/src/rc/example_u8.rs
+++ b/circ_hc/src/rc/example_u8.rs
@@ -183,15 +183,6 @@ impl Manager {
             let mut to_collect = self.to_collect.borrow_mut();
             let mut gc_hooks = self.gc_hooks.borrow_mut();
             let mut collected = 0;
-            //let mut to_collect: Vec<Node> = Vec::new();
-            //        table.retain(|_, value| {
-            //            if Rc::strong_count(&value.data) > 2 {
-            //                true
-            //            } else {
-            //                to_collect.push(value.clone());
-            //                false
-            //            }
-            //        });
             while let Some(t) = to_collect.pop() {
                 collected += 1;
                 let id = t.id;

--- a/circ_hc/src/rc/example_u8.rs
+++ b/circ_hc/src/rc/example_u8.rs
@@ -2,6 +2,7 @@
 use fxhash::FxHashMap as HashMap;
 
 use crate::Id;
+use log::trace;
 use std::borrow::Borrow;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -111,6 +112,9 @@ impl crate::Table<u8> for Table {
 
 struct Manager {
     table: RefCell<HashMap<Rc<NodeData>, Node>>,
+    /// Elements that are still in `table`, but should be collected.
+    to_collect: RefCell<Vec<Weak>>,
+    in_gc: Cell<bool>,
     next_id: Cell<Id>,
     /// a Vec map from [String] to function
     gc_hooks: RefCell<(Vec<String>, Vec<Box<dyn Fn(Id) -> Vec<Node>>>)>,
@@ -141,15 +145,11 @@ impl std::fmt::Debug for Manager {
 thread_local! {
     static MANAGER: Manager = Manager {
         table: Default::default(),
+        to_collect: Default::default(),
+        in_gc: Cell::new(false),
         next_id: Cell::new(Id(0)),
         gc_hooks: Default::default(),
     };
-}
-
-impl Node {
-    fn try_unwrap(self) -> Result<NodeData, Self> {
-        Rc::try_unwrap(self.data).map_err(|data| Node { data, id: self.id })
-    }
 }
 
 impl Manager {
@@ -175,44 +175,66 @@ impl Manager {
     }
 
     fn force_gc(&self) -> usize {
-        let mut table = self.table.borrow_mut();
-        let old_size = table.len();
-        let mut to_collect: Vec<Node> = Vec::new();
-        table.retain(|_, value| {
-            if Rc::strong_count(&value.data) > 2 {
-                true
-            } else {
-                to_collect.push(value.clone());
-                false
-            }
-        });
-        while let Some(t) = to_collect.pop() {
-            let id = t.id;
-            let data = Node::try_unwrap(t).unwrap_or_else(|node| {
-                panic!(
-                    "Attempting to collect node {:?}. but it has >1 ref",
-                    NodeShallowDebug(&node)
-                )
-            });
-            for c in data.cs.into_vec() {
-                if Rc::strong_count(&c.data) <= 3 {
-                    debug_assert_eq!(Rc::strong_count(&c.data), 3);
-                    table.remove(&c.data);
-                    to_collect.push(c.clone());
+        if !std::thread::panicking() {
+            let start = std::time::Instant::now();
+            assert!(!self.in_gc.get(), "Double GC");
+            self.in_gc.set(true);
+            let mut table = self.table.borrow_mut();
+            let mut to_collect = self.to_collect.borrow_mut();
+            let mut gc_hooks = self.gc_hooks.borrow_mut();
+            let mut collected = 0;
+            //let mut to_collect: Vec<Node> = Vec::new();
+            //        table.retain(|_, value| {
+            //            if Rc::strong_count(&value.data) > 2 {
+            //                true
+            //            } else {
+            //                to_collect.push(value.clone());
+            //                false
+            //            }
+            //        });
+            while let Some(t) = to_collect.pop() {
+                collected += 1;
+                let id = t.id;
+                if t.data.strong_count() != 2 {
+                    continue;
                 }
-            }
-            for h in self.gc_hooks.borrow_mut().1.iter_mut() {
-                for c in h(id) {
+                let strong_data = t.data.upgrade().expect("missing from table");
+                table.remove(&strong_data).expect("missing from table");
+                let data = Rc::try_unwrap(strong_data).unwrap_or_else(|d| {
+                    panic!("to many refs to {:?}", NodeListShallowDebug(&d.cs))
+                });
+                for c in data.cs.into_vec() {
+                    // 3 pointers: 2 from table, and this vector.
                     if Rc::strong_count(&c.data) <= 3 {
                         debug_assert_eq!(Rc::strong_count(&c.data), 3);
-                        table.remove(&c.data);
-                        to_collect.push(c.clone());
+                        use crate::Node;
+                        to_collect.push(c.downgrade());
+                    }
+                }
+                for h in gc_hooks.1.iter_mut() {
+                    for c in h(id) {
+                        // 3 pointers: 2 from table, and this vector.
+                        if Rc::strong_count(&c.data) <= 3 {
+                            debug_assert_eq!(Rc::strong_count(&c.data), 3);
+                            use crate::Node;
+                            to_collect.push(c.downgrade());
+                        }
                     }
                 }
             }
+            let new_size = table.len();
+            let duration = start.elapsed();
+            self.in_gc.set(false);
+            trace!(
+                "GC: {} terms -> {} terms in {} us",
+                collected,
+                new_size,
+                duration.as_micros()
+            );
+            collected
+        } else {
+            0
         }
-        let new_size = table.len();
-        old_size - new_size
     }
 }
 
@@ -239,6 +261,22 @@ impl crate::Node<u8> for Node {
         Weak {
             data: Rc::downgrade(&self.data),
             id: self.id,
+        }
+    }
+}
+
+impl Drop for Node {
+    fn drop(&mut self) {
+        use crate::Node;
+        // 3 pointers: 2 from table, and this one.
+        if self.ref_cnt() <= 3 && !std::thread::panicking() {
+            MANAGER
+                .try_with(|m| {
+                    if !m.in_gc.get() {
+                        m.to_collect.borrow_mut().push(self.downgrade());
+                    }
+                })
+                .ok();
         }
     }
 }
@@ -353,9 +391,13 @@ mod cmp {
 
 impl std::ops::Drop for Manager {
     fn drop(&mut self) {
-        // If we just drop everything in the table, then that can lead to deep Rc::drop recursions.
+        // If we just drop everything in the table, there can be deep Rc::drop recursions.
         //
         // If we run GC, then hopefully we avoid that.
-        self.force_gc();
+        //
+        // However, running GC takes a long time. This could probably be improved.
+        if !std::thread::panicking() {
+            self.force_gc();
+        }
     }
 }

--- a/circ_hc/src/rc/macro_.rs
+++ b/circ_hc/src/rc/macro_.rs
@@ -4,6 +4,7 @@ macro_rules! generate_hashcons_rc {
     ($Op:ty) => {
         use fxhash::FxHashMap as HashMap;
 
+        use log::trace;
         use std::borrow::Borrow;
         use std::cell::{Cell, RefCell};
         use std::rc::Rc;
@@ -114,6 +115,9 @@ macro_rules! generate_hashcons_rc {
 
         struct Manager {
             table: RefCell<HashMap<Rc<NodeData>, Node>>,
+            /// Elements that are still in `table`, but should be collected.
+            to_collect: RefCell<Vec<Weak>>,
+            in_gc: Cell<bool>,
             next_id: Cell<Id>,
             /// a Vec map from [String] to function
             gc_hooks: RefCell<(Vec<String>, Vec<Box<dyn Fn(Id) -> Vec<Node>>>)>,
@@ -144,15 +148,11 @@ macro_rules! generate_hashcons_rc {
         thread_local! {
             static MANAGER: Manager = Manager {
                 table: Default::default(),
+                to_collect: Default::default(),
+                in_gc: Cell::new(false),
                 next_id: Cell::new(Id(0)),
                 gc_hooks: Default::default(),
             };
-        }
-
-        impl Node {
-            fn try_unwrap(self) -> Result<NodeData, Self> {
-                Rc::try_unwrap(self.data).map_err(|data| Node { data, id: self.id })
-            }
         }
 
         impl Manager {
@@ -178,44 +178,66 @@ macro_rules! generate_hashcons_rc {
             }
 
             fn force_gc(&self) -> usize {
-                let mut table = self.table.borrow_mut();
-                let old_size = table.len();
-                let mut to_collect: Vec<Node> = Vec::new();
-                table.retain(|_, value| {
-                    if Rc::strong_count(&value.data) > 2 {
-                        true
-                    } else {
-                        to_collect.push(value.clone());
-                        false
-                    }
-                });
-                while let Some(t) = to_collect.pop() {
-                    let id = t.id;
-                    let data = Node::try_unwrap(t).unwrap_or_else(|node| {
-                        panic!(
-                            "Attempting to collect node {:?}. but it has >1 ref",
-                            NodeShallowDebug(&node)
-                        )
-                    });
-                    for c in data.cs.into_vec() {
-                        if Rc::strong_count(&c.data) <= 3 {
-                            debug_assert_eq!(Rc::strong_count(&c.data), 3);
-                            table.remove(&c.data);
-                            to_collect.push(c.clone());
+                if !std::thread::panicking() {
+                    let start = std::time::Instant::now();
+                    assert!(!self.in_gc.get(), "Double GC");
+                    self.in_gc.set(true);
+                    let mut table = self.table.borrow_mut();
+                    let mut to_collect = self.to_collect.borrow_mut();
+                    let mut gc_hooks = self.gc_hooks.borrow_mut();
+                    let mut collected = 0;
+                    //let mut to_collect: Vec<Node> = Vec::new();
+                    //        table.retain(|_, value| {
+                    //            if Rc::strong_count(&value.data) > 2 {
+                    //                true
+                    //            } else {
+                    //                to_collect.push(value.clone());
+                    //                false
+                    //            }
+                    //        });
+                    while let Some(t) = to_collect.pop() {
+                        collected += 1;
+                        let id = t.id;
+                        if t.data.strong_count() != 2 {
+                            continue;
                         }
-                    }
-                    for h in self.gc_hooks.borrow_mut().1.iter_mut() {
-                        for c in h(id) {
+                        let strong_data = t.data.upgrade().expect("missing from table");
+                        table.remove(&strong_data).expect("missing from table");
+                        let data = Rc::try_unwrap(strong_data).unwrap_or_else(|d| {
+                            panic!("to many refs to {:?}", NodeListShallowDebug(&d.cs))
+                        });
+                        for c in data.cs.into_vec() {
+                            // 3 pointers: 2 from table, and this vector.
                             if Rc::strong_count(&c.data) <= 3 {
                                 debug_assert_eq!(Rc::strong_count(&c.data), 3);
-                                table.remove(&c.data);
-                                to_collect.push(c.clone());
+                                use $crate::Node;
+                                to_collect.push(c.downgrade());
+                            }
+                        }
+                        for h in gc_hooks.1.iter_mut() {
+                            for c in h(id) {
+                                // 3 pointers: 2 from table, and this vector.
+                                if Rc::strong_count(&c.data) <= 3 {
+                                    debug_assert_eq!(Rc::strong_count(&c.data), 3);
+                                    use $crate::Node;
+                                    to_collect.push(c.downgrade());
+                                }
                             }
                         }
                     }
+                    let new_size = table.len();
+                    let duration = start.elapsed();
+                    self.in_gc.set(false);
+                    trace!(
+                        "GC: {} terms -> {} terms in {} us",
+                        collected,
+                        new_size,
+                        duration.as_micros()
+                    );
+                    collected
+                } else {
+                    0
                 }
-                let new_size = table.len();
-                old_size - new_size
             }
         }
 
@@ -242,6 +264,22 @@ macro_rules! generate_hashcons_rc {
                 Weak {
                     data: Rc::downgrade(&self.data),
                     id: self.id,
+                }
+            }
+        }
+
+        impl Drop for Node {
+            fn drop(&mut self) {
+                use $crate::Node;
+                // 3 pointers: 2 from table, and this one.
+                if self.ref_cnt() <= 3 && !std::thread::panicking() {
+                    MANAGER
+                        .try_with(|m| {
+                            if !m.in_gc.get() {
+                                m.to_collect.borrow_mut().push(self.downgrade());
+                            }
+                        })
+                        .ok();
                 }
             }
         }
@@ -356,10 +394,14 @@ macro_rules! generate_hashcons_rc {
 
         impl std::ops::Drop for Manager {
             fn drop(&mut self) {
-                // If we just drop everything in the table, then that can lead to deep Rc::drop recursions.
+                // If we just drop everything in the table, there can be deep Rc::drop recursions.
                 //
                 // If we run GC, then hopefully we avoid that.
-                self.force_gc();
+                //
+                // However, running GC takes a long time. This could probably be improved.
+                if !std::thread::panicking() {
+                    self.force_gc();
+                }
             }
         }
     };

--- a/circ_hc/src/rc/macro_.rs
+++ b/circ_hc/src/rc/macro_.rs
@@ -186,15 +186,6 @@ macro_rules! generate_hashcons_rc {
                     let mut to_collect = self.to_collect.borrow_mut();
                     let mut gc_hooks = self.gc_hooks.borrow_mut();
                     let mut collected = 0;
-                    //let mut to_collect: Vec<Node> = Vec::new();
-                    //        table.retain(|_, value| {
-                    //            if Rc::strong_count(&value.data) > 2 {
-                    //                true
-                    //            } else {
-                    //                to_collect.push(value.clone());
-                    //                false
-                    //            }
-                    //        });
                     while let Some(t) = to_collect.pop() {
                         collected += 1;
                         let id = t.id;

--- a/circ_hc/src/rc/template.rs
+++ b/circ_hc/src/rc/template.rs
@@ -1,6 +1,7 @@
 use fxhash::FxHashMap as HashMap;
 
 use crate::Id;
+use log::trace;
 use std::borrow::Borrow;
 use std::cell::{Cell, RefCell};
 use std::net::SocketAddrV6 as TemplateOp;
@@ -111,6 +112,9 @@ impl crate::Table<TemplateOp> for Table {
 
 struct Manager {
     table: RefCell<HashMap<Rc<NodeData>, Node>>,
+    /// Elements that are still in `table`, but should be collected.
+    to_collect: RefCell<Vec<Weak>>,
+    in_gc: Cell<bool>,
     next_id: Cell<Id>,
     /// a Vec map from [String] to function
     gc_hooks: RefCell<(Vec<String>, Vec<Box<dyn Fn(Id) -> Vec<Node>>>)>,
@@ -141,15 +145,11 @@ impl std::fmt::Debug for Manager {
 thread_local! {
     static MANAGER: Manager = Manager {
         table: Default::default(),
+        to_collect: Default::default(),
+        in_gc: Cell::new(false),
         next_id: Cell::new(Id(0)),
         gc_hooks: Default::default(),
     };
-}
-
-impl Node {
-    fn try_unwrap(self) -> Result<NodeData, Self> {
-        Rc::try_unwrap(self.data).map_err(|data| Node { data, id: self.id })
-    }
 }
 
 impl Manager {
@@ -175,44 +175,66 @@ impl Manager {
     }
 
     fn force_gc(&self) -> usize {
-        let mut table = self.table.borrow_mut();
-        let old_size = table.len();
-        let mut to_collect: Vec<Node> = Vec::new();
-        table.retain(|_, value| {
-            if Rc::strong_count(&value.data) > 2 {
-                true
-            } else {
-                to_collect.push(value.clone());
-                false
-            }
-        });
-        while let Some(t) = to_collect.pop() {
-            let id = t.id;
-            let data = Node::try_unwrap(t).unwrap_or_else(|node| {
-                panic!(
-                    "Attempting to collect node {:?}. but it has >1 ref",
-                    NodeShallowDebug(&node)
-                )
-            });
-            for c in data.cs.into_vec() {
-                if Rc::strong_count(&c.data) <= 3 {
-                    debug_assert_eq!(Rc::strong_count(&c.data), 3);
-                    table.remove(&c.data);
-                    to_collect.push(c.clone());
+        if !std::thread::panicking() {
+            let start = std::time::Instant::now();
+            assert!(!self.in_gc.get(), "Double GC");
+            self.in_gc.set(true);
+            let mut table = self.table.borrow_mut();
+            let mut to_collect = self.to_collect.borrow_mut();
+            let mut gc_hooks = self.gc_hooks.borrow_mut();
+            let mut collected = 0;
+            //let mut to_collect: Vec<Node> = Vec::new();
+            //        table.retain(|_, value| {
+            //            if Rc::strong_count(&value.data) > 2 {
+            //                true
+            //            } else {
+            //                to_collect.push(value.clone());
+            //                false
+            //            }
+            //        });
+            while let Some(t) = to_collect.pop() {
+                collected += 1;
+                let id = t.id;
+                if t.data.strong_count() != 2 {
+                    continue
                 }
-            }
-            for h in self.gc_hooks.borrow_mut().1.iter_mut() {
-                for c in h(id) {
+                let strong_data = t.data.upgrade().expect("missing from table");
+                table.remove(&strong_data).expect("missing from table");
+                let data = Rc::try_unwrap(strong_data).unwrap_or_else(|d| {
+                    panic!("to many refs to {:?}", NodeListShallowDebug(&d.cs))
+                });
+                for c in data.cs.into_vec() {
+                    // 3 pointers: 2 from table, and this vector.
                     if Rc::strong_count(&c.data) <= 3 {
                         debug_assert_eq!(Rc::strong_count(&c.data), 3);
-                        table.remove(&c.data);
-                        to_collect.push(c.clone());
+                        use crate::Node;
+                        to_collect.push(c.downgrade());
+                    }
+                }
+                for h in gc_hooks.1.iter_mut() {
+                    for c in h(id) {
+                        // 3 pointers: 2 from table, and this vector.
+                        if Rc::strong_count(&c.data) <= 3 {
+                            debug_assert_eq!(Rc::strong_count(&c.data), 3);
+                            use crate::Node;
+                            to_collect.push(c.downgrade());
+                        }
                     }
                 }
             }
+            let new_size = table.len();
+            let duration = start.elapsed();
+            self.in_gc.set(false);
+            trace!(
+                "GC: {} terms -> {} terms in {} us",
+                collected,
+                new_size,
+                duration.as_micros()
+            );
+            collected
+        } else {
+            0
         }
-        let new_size = table.len();
-        old_size - new_size
     }
 }
 
@@ -239,6 +261,22 @@ impl crate::Node<TemplateOp> for Node {
         Weak {
             data: Rc::downgrade(&self.data),
             id: self.id,
+        }
+    }
+}
+
+impl Drop for Node {
+    fn drop(&mut self) {
+        use crate::Node;
+        // 3 pointers: 2 from table, and this one.
+        if self.ref_cnt() <= 3 && !std::thread::panicking() {
+            MANAGER
+                .try_with(|m| {
+                    if !m.in_gc.get() {
+                        m.to_collect.borrow_mut().push(self.downgrade());
+                    }
+                })
+                .ok();
         }
     }
 }
@@ -358,6 +396,8 @@ impl std::ops::Drop for Manager {
         // If we run GC, then hopefully we avoid that.
         //
         // However, running GC takes a long time. This could probably be improved.
-        self.force_gc();
+        if !std::thread::panicking() {
+            self.force_gc();
+        }
     }
 }

--- a/circ_hc/src/rc/template.rs
+++ b/circ_hc/src/rc/template.rs
@@ -183,20 +183,11 @@ impl Manager {
             let mut to_collect = self.to_collect.borrow_mut();
             let mut gc_hooks = self.gc_hooks.borrow_mut();
             let mut collected = 0;
-            //let mut to_collect: Vec<Node> = Vec::new();
-            //        table.retain(|_, value| {
-            //            if Rc::strong_count(&value.data) > 2 {
-            //                true
-            //            } else {
-            //                to_collect.push(value.clone());
-            //                false
-            //            }
-            //        });
             while let Some(t) = to_collect.pop() {
                 collected += 1;
                 let id = t.id;
                 if t.data.strong_count() != 2 {
-                    continue
+                    continue;
                 }
                 let strong_data = t.data.upgrade().expect("missing from table");
                 table.remove(&strong_data).expect("missing from table");

--- a/circ_hc/src/test/mod.rs
+++ b/circ_hc/src/test/mod.rs
@@ -167,6 +167,7 @@ mod rc {
         crate::rc::generate_hashcons!(u8);
     }
     use hc_u8::Table;
+    //use crate::rc::example_u8::Table;
 
     mod tiny {
         #[test]

--- a/circ_hc/src/test/tiny.rs
+++ b/circ_hc/src/test/tiny.rs
@@ -6,7 +6,7 @@ pub fn one<T: Table<u8>>() {
     let n = T::create_ref(&1, []);
     assert_eq!(T::table_size(), 1);
     std::mem::drop(n);
-    T::gc();
+    assert_eq!(1, T::gc());
     assert_eq!(T::table_size(), 0);
 }
 


### PR DESCRIPTION
Previously, a GC call would scan the HC table, identifying dead nodes.

Now, whenever a `Node` is destroyed, if it's ready to be GC'd, it gets added to a list. That list is used at GC time instead of the scan.

This substantially decreases the cost of running GC many times (as the Z# FE does).