### PR TITLE
Improve RAM: oblivious & volatile

### DIFF
--- a/src/ir/opt/mem/ram/volatile.rs
+++ b/src/ir/opt/mem/ram/volatile.rs
@@ -318,8 +318,8 @@ impl RewritePass for Extactor {
         let term_refs: HashSet<&Term> = terms.iter().collect();
         let mut cache = TermMap::<Term>::default();
         for top in array_order(term_refs) {
-            debug_assert!(!cache.contains_key(&top));
-            let new_t_opt = self.visit_cache(computation, &top, &cache);
+            debug_assert!(!cache.contains_key(top));
+            let new_t_opt = self.visit_cache(computation, top, &cache);
             let new_t = new_t_opt.unwrap_or_else(|| {
                 term(
                     top.op().clone(),

--- a/src/ir/opt/mem/ram/volatile.rs
+++ b/src/ir/opt/mem/ram/volatile.rs
@@ -1,6 +1,10 @@
 //! A general-purpose RAM extractor
 use super::*;
 
+use fxhash::FxHashMap as HashMap;
+use fxhash::FxHashSet as HashSet;
+use std::collections::BinaryHeap;
+
 use log::trace;
 
 /// Graph of the *arrays* in the computation.
@@ -198,6 +202,46 @@ impl Extactor {
     }
 }
 
+/// Given a set of terms, return an ordering of them in post-order, but also with array selects on
+/// A before stores to A.
+fn array_order<'a>(terms: HashSet<&'a Term>) -> Vec<&'a Term> {
+    let mut parents: HashMap<&'a Term, HashSet<&'a Term>> = Default::default();
+    let mut children: HashMap<&'a Term, HashSet<&'a Term>> = Default::default();
+    for t in &terms {
+        parents.entry(t).or_default();
+        children.entry(t).or_default();
+        for c in t.cs() {
+            debug_assert!(terms.contains(c));
+            parents.entry(c).or_default().insert(t);
+            children.entry(t).or_default().insert(c);
+        }
+    }
+    let mut output: Vec<&'a Term> = Default::default();
+    // max-heap contains (is_select, term) pairs; so, selects go first.
+    let mut to_output: BinaryHeap<(bool, &'a Term)> = terms
+        .iter()
+        .filter(|t| t.cs().is_empty())
+        .map(|t| (false, *t))
+        .collect();
+    let mut children_not_outputted: HashMap<&'a Term, usize> = children
+        .iter()
+        .map(|(term, children)| (*term, children.len()))
+        .collect();
+    while let Some((_, output_me)) = to_output.pop() {
+        output.push(output_me);
+        for p in parents.get(&output_me).unwrap() {
+            let count = children_not_outputted.get_mut(p).unwrap();
+            assert!(*count > 0);
+            *count -= 1;
+            if *count == 0 {
+                to_output.push((matches!(p.op(), Op::Select), *p));
+            }
+        }
+    }
+    assert_eq!(output.len(), terms.len());
+    output
+}
+
 impl RewritePass for Extactor {
     fn visit<F: Fn() -> Vec<Term>>(
         &mut self,
@@ -242,15 +286,57 @@ impl RewritePass for Extactor {
             match &t.op() {
                 // Rewrite select's whose array is a RAM term
                 Op::Select if self.graph.ram_terms.contains(&t.cs()[0]) => {
-                    let ram_id = self.get_or_start(&t.cs()[0]);
+                    let array = &t.cs()[0];
+                    let idx = &t.cs()[1];
+                    // If we're based on a leaf
+                    let ram_id = if array_leaf(array) {
+                        // check if that leaf has a RAM already
+                        if let Some(id) = self.term_ram.get(array) {
+                            *id
+                        } else {
+                            let id = self.start_ram_for_leaf(array);
+
+                            self.term_ram.insert(array.clone(), id);
+                            id
+                        }
+                    } else {
+                        // otherwise, assume that our parent has a RAM already
+                        *self.term_ram.get(array).unwrap()
+                    };
                     let ram = &mut self.rams[ram_id];
-                    let read_value = ram.new_read(t.cs()[1].clone(), computation, t.clone());
+                    let read_value = ram.new_read(idx.clone(), computation, t.clone());
                     self.read_terms.insert(t.clone(), read_value.clone());
                     Some(read_value)
                 }
                 _ => None,
             }
         }
+    }
+
+    fn traverse(&mut self, computation: &mut Computation) {
+        let terms: Vec<Term> = computation.terms_postorder().collect();
+        let term_refs: HashSet<&Term> = terms.iter().collect();
+        let mut cache = TermMap::<Term>::default();
+        for top in array_order(term_refs) {
+            debug_assert!(!cache.contains_key(&top));
+            let new_t_opt = self.visit_cache(computation, &top, &cache);
+            let new_t = new_t_opt.unwrap_or_else(|| {
+                term(
+                    top.op().clone(),
+                    top.cs()
+                        .iter()
+                        .map(|c| cache.get(c).unwrap())
+                        .cloned()
+                        .collect(),
+                )
+            });
+            cache.insert(top.clone(), new_t);
+        }
+        computation.outputs = computation
+            .outputs
+            .iter()
+            .map(|o| cache.get(o).unwrap().clone())
+            .collect();
     }
 }
 
@@ -515,6 +601,83 @@ mod test {
         let rams = extract(&mut cs2, AccessCfg::default_from_field(field));
         assert_eq!(0, rams.len());
         assert_eq!(cs, cs2);
+    }
+
+    #[test]
+    fn rom() {
+        let cs = text::parse_computation(
+            b"
+                (computation
+                    (metadata (parties ) (inputs ) (commitments))
+                    (precompute () () (#t ))
+                    (set_default_modulus 11
+                    (let
+                        (
+                            (c_array (#a (mod 11) #f0 4 ()))
+                            (x0 (select c_array #f0))
+                            (x1 (select c_array #f1))
+                            (x2 (select c_array #f2))
+                            (x3 (select c_array #f3))
+                        )
+                        (+ x0 x1 x2 x3)
+                    ))
+                )
+            ",
+        );
+        let mut cs2 = cs.clone();
+        cstore::parse(&mut cs2);
+        let field = FieldT::from(rug::Integer::from(11));
+        let rams = extract(&mut cs2, AccessCfg::default_from_field(field.clone()));
+        extras::assert_all_vars_declared(&cs2);
+        assert_ne!(cs, cs2);
+        assert_eq!(1, rams.len());
+        assert_eq!(4, rams[0].accesses.len());
+    }
+
+    #[test]
+    fn multi_arm_tree() {
+        let cs = text::parse_computation(
+            b"
+                (computation
+                    (metadata (parties ) (inputs ) (commitments))
+                    (precompute () () (#t ))
+                    (set_default_modulus 11
+                    (let
+                        (
+                            (a0 (#a (mod 11) #f0 4 ()))
+                            (a1 (store a0 #f0 #f1))
+                            (x0 (select a1 #f0))
+                            (x1 (select a1 #f1))
+                            (a2 (store a1 #f0 #f1))
+                            (x2 (select a2 #f2))
+                            (x3 (select a2 #f3))
+                            (a3 (store a2 #f1 #f1))
+                            (x4 (select a3 #f0))
+                            (x5 (select a3 #f1))
+                        )
+                        (+ x0 x1 x2 x3 x4 x5)
+                    ))
+                )
+            ",
+        );
+        let mut cs2 = cs.clone();
+        cstore::parse(&mut cs2);
+        let field = FieldT::from(rug::Integer::from(11));
+        let rams = extract(&mut cs2, AccessCfg::default_from_field(field.clone()));
+        extras::assert_all_vars_declared(&cs2);
+        assert_ne!(cs, cs2);
+        assert_eq!(1, rams.len());
+        assert_eq!(9, rams[0].accesses.len());
+        println!("{:?}", rams[0].accesses);
+        assert_eq!(bool_lit(true), rams[0].accesses[0].write.b);
+        assert_eq!(bool_lit(false), rams[0].accesses[1].write.b);
+        assert_eq!(bool_lit(false), rams[0].accesses[2].write.b);
+        assert_eq!(bool_lit(true), rams[0].accesses[3].write.b);
+        assert_eq!(bool_lit(false), rams[0].accesses[4].write.b);
+        assert_eq!(bool_lit(false), rams[0].accesses[5].write.b);
+        assert_eq!(bool_lit(true), rams[0].accesses[6].write.b);
+        assert_eq!(bool_lit(false), rams[0].accesses[7].write.b);
+        assert_eq!(bool_lit(false), rams[0].accesses[8].write.b);
     }
 
     #[cfg(feature = "poly")]

--- a/src/ir/opt/mod.rs
+++ b/src/ir/opt/mod.rs
@@ -86,7 +86,7 @@ pub fn opt<I: IntoIterator<Item = Opt>>(mut cs: Computations, optimizations: I) 
                     }
                 }
                 Opt::Obliv => {
-                    mem::obliv::new_elim_obliv(c);
+                    mem::obliv::elim_obliv(c);
                 }
                 Opt::LinearScan => {
                     mem::lin::linearize(c);

--- a/src/ir/opt/mod.rs
+++ b/src/ir/opt/mod.rs
@@ -86,7 +86,7 @@ pub fn opt<I: IntoIterator<Item = Opt>>(mut cs: Computations, optimizations: I) 
                     }
                 }
                 Opt::Obliv => {
-                    mem::obliv::elim_obliv(c);
+                    mem::obliv::new_elim_obliv(c);
                 }
                 Opt::LinearScan => {
                     mem::lin::linearize(c);

--- a/src/ir/term/extras.rs
+++ b/src/ir/term/extras.rs
@@ -110,6 +110,7 @@ pub fn as_uint_constant(t: &Term) -> Option<Integer> {
     match &t.op() {
         Op::Const(Value::BitVector(bv)) => Some(bv.uint().clone()),
         Op::Const(Value::Field(f)) => Some(f.i()),
+        Op::Const(Value::Bool(b)) => Some((*b).into()),
         _ => None,
     }
 }


### PR DESCRIPTION
* Improve the oblivious RAM pass by killing the hack where we treat selects as arrays.
* Fix a bug where the volatile RAM pass would not place selects before stores against the same array
* Improve that volatile RAM pass by placing selects against the same array literal in *the same RAM*. Before, they would each end up in different RAMs, which sucks. This is especially bad for ROMs.