### PR TITLE
optimize prover: buffered IO

### DIFF
--- a/src/target/r1cs/proof.rs
+++ b/src/target/r1cs/proof.rs
@@ -1,8 +1,8 @@
 //! A trait for CirC-compatible proofs
 
 use std::fs::File;
-use std::path::Path;
 use std::io::{BufReader, BufWriter};
+use std::path::Path;
 
 use bincode::{deserialize_from, serialize_into};
 use fxhash::FxHashMap as HashMap;

--- a/src/target/r1cs/proof.rs
+++ b/src/target/r1cs/proof.rs
@@ -2,6 +2,7 @@
 
 use std::fs::File;
 use std::path::Path;
+use std::io::{BufReader, BufWriter};
 
 use bincode::{deserialize_from, serialize_into};
 use fxhash::FxHashMap as HashMap;
@@ -12,7 +13,7 @@ use crate::ir::term::text::parse_value_map;
 use crate::ir::term::Value;
 
 fn serialize_into_file<S: Serialize, P: AsRef<Path>>(data: &S, path: P) -> std::io::Result<()> {
-    let mut file = File::create(path.as_ref())?;
+    let mut file = BufWriter::new(File::create(path.as_ref())?);
     serialize_into(&mut file, data).unwrap();
     Ok(())
 }
@@ -20,7 +21,7 @@ fn serialize_into_file<S: Serialize, P: AsRef<Path>>(data: &S, path: P) -> std::
 fn deserialize_from_file<D: for<'a> Deserialize<'a>, P: AsRef<Path>>(
     path: P,
 ) -> std::io::Result<D> {
-    Ok(deserialize_from(File::open(path.as_ref())?).unwrap())
+    Ok(deserialize_from(BufReader::new(File::open(path.as_ref())?)).unwrap())
 }
 
 fn value_map_from_path<P: AsRef<Path>>(path: P) -> std::io::Result<HashMap<String, Value>> {

--- a/src/target/r1cs/spartan.rs
+++ b/src/target/r1cs/spartan.rs
@@ -10,6 +10,7 @@ use merlin::Transcript;
 use rug::Integer;
 use std::fs::File;
 use std::io;
+use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
 /// Hold Spartan variables
@@ -244,25 +245,25 @@ pub fn write_data<P1: AsRef<Path>, P2: AsRef<Path>>(
 }
 
 fn write_prover_data<P: AsRef<Path>>(path: P, data: &ProverData) -> io::Result<()> {
-    let mut file = File::create(path)?;
+    let mut file = BufWriter::new(File::create(path)?);
     serialize_into(&mut file, &data).unwrap();
     Ok(())
 }
 
 fn read_prover_data<P: AsRef<Path>>(path: P) -> io::Result<ProverData> {
-    let mut file = File::open(path)?;
+    let mut file = BufReader::new(File::open(path)?);
     let data: ProverData = deserialize_from(&mut file).unwrap();
     Ok(data)
 }
 
 fn write_verifier_data<P: AsRef<Path>>(path: P, data: &VerifierData) -> io::Result<()> {
-    let mut file = File::create(path)?;
+    let mut file = BufWriter::new(File::create(path)?);
     serialize_into(&mut file, &data).unwrap();
     Ok(())
 }
 
 fn read_verifier_data<P: AsRef<Path>>(path: P) -> io::Result<VerifierData> {
-    let mut file = File::open(path)?;
+    let mut file = BufReader::new(File::open(path)?);
     let data: VerifierData = deserialize_from(&mut file).unwrap();
     Ok(data)
 }


### PR DESCRIPTION
Both the bellman and spartan backends were using unbuffered IO. Ouch.