### PR TITLE
bugfix: opt::mem::obliv

### DIFF
--- a/examples/ZoKrates/pf/2024_06_02_chad_bug.zok
+++ b/examples/ZoKrates/pf/2024_06_02_chad_bug.zok
@@ -1,0 +1,22 @@
+struct BigNat_init_quotient<Qm1, Lp1> {
+    field[Qm1][Lp1] limbs
+    field last_limb
+}
+
+struct BigNat_init<N, Lp1> {
+    field[N][Lp1] limbs
+}
+struct BigNatModMult_init<Qm1, Lp1, ZG, CL> {
+    BigNat_init_quotient<Qm1, Lp1> quotient_init
+    BigNat_init<ZG, CL> carry_init
+}
+
+const u32 Qm1 = 7
+const u32 Lp1 = 4
+const u32 ZG = 2
+const u32 CL = 5
+
+def main(private BigNatModMult_init<Qm1,Lp1,ZG,CL>[1] intermediate_mod) -> bool:
+    BigNat_init<ZG, CL> carry = intermediate_mod[0].carry_init
+    assert(carry.limbs[0][0] == 1)
+    return true

--- a/scripts/zokrates_test.zsh
+++ b/scripts/zokrates_test.zsh
@@ -88,6 +88,7 @@ r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/utils/casts/bool_128_to_
 r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/ecc/edwardsScalarMult.zok
 r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/hashes/mimc7/mimc7R20.zok
 r1cs_test ./third_party/ZoKrates/zokrates_stdlib/stdlib/hashes/pedersen/512bit.zok
+r1cs_test ./examples/ZoKrates/pf/2024_06_02_chad_bug.zok
 
 pf_test_only_pf sha_temp1
 pf_test_only_pf sha_rot

--- a/src/ir/opt/mem/obliv.rs
+++ b/src/ir/opt/mem/obliv.rs
@@ -42,6 +42,7 @@ impl OblivRewriter {
     }
     fn visit(&mut self, t: &Term) {
         let (tup_opt, term_opt) = match t.op() {
+            Op::Var(_, sort) if sort.is_scalar() => (Some(t.clone()), None),
             Op::Const(v @ Value::Array(_)) => (Some(leaf_term(Op::Const(arr_val_to_tup(v)))), None),
             Op::Array(_k, _v) => (
                 Some(term(


### PR DESCRIPTION
recognize scalar variables as tuple-free