### PR TITLE
Reduce the number of rounds in ROM checking to 2.

### DIFF
--- a/examples/circ.rs
+++ b/examples/circ.rs
@@ -322,6 +322,7 @@ fn main() {
                 println!("R1CS stats: {:#?}", r1cs.stats());
             }
             let (prover_data, verifier_data) = r1cs.finalize(cs);
+            println!("Final R1cs rounds: {}", prover_data.precompute.stage_sizes().count() - 1);
             match action {
                 ProofAction::Count => (),
                 #[cfg(feature = "bellman")]

--- a/examples/circ.rs
+++ b/examples/circ.rs
@@ -322,7 +322,10 @@ fn main() {
                 println!("R1CS stats: {:#?}", r1cs.stats());
             }
             let (prover_data, verifier_data) = r1cs.finalize(cs);
-            println!("Final R1cs rounds: {}", prover_data.precompute.stage_sizes().count() - 1);
+            println!(
+                "Final R1cs rounds: {}",
+                prover_data.precompute.stage_sizes().count() - 1
+            );
             match action {
                 ProofAction::Count => (),
                 #[cfg(feature = "bellman")]

--- a/src/ir/opt/mem/ram/checker.rs
+++ b/src/ir/opt/mem/ram/checker.rs
@@ -257,7 +257,7 @@ pub fn haboeck_range_check(
     let ns = ns.subspace("range");
     let f_sort = Sort::Field(f.clone());
     let haystack: Vec<Term> = f_sort.elems_iter().take(n).collect();
-    assertions.push(rom::lookup(c, ns, haystack, values));
+    assertions.push(rom::lookup(c, ns, haystack, values, None));
 }
 
 /// Ensure that each element of `values` is in `[0, n)`.

--- a/src/ir/opt/mem/ram/set.rs
+++ b/src/ir/opt/mem/ram/set.rs
@@ -50,6 +50,7 @@ pub fn apply(c: &mut Computation) {
             ns.subspace(format!("setmem{}", i)),
             haystack,
             keys,
+            None,
         ));
     }
     to_assert.push(c.outputs[0].clone());


### PR DESCRIPTION
It was spuriously three because of imprecise dependency tracking