### PR TITLE
Fix some const asserts not throwing errors

### DIFF
--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -1251,7 +1251,7 @@ impl<'ast> ZGen<'ast> {
                 .map_err(|e| format!("{e}"))
             }
             ast::Statement::Assertion(e) => {
-                match self.expr_impl_::<true>(&e.expression).and_then(|v| {
+                match self.expr_impl_::<false>(&e.expression).and_then(|v| {
                     const_bool(v)
                         .ok_or_else(|| "interpreting expr as const bool failed".to_string())
                 }) {


### PR DESCRIPTION
Currently some assertions that can be statically determined to be false, do not cause a compile time error to be thrown, while some do.

For example,

```
def main() -> bool:
    assert(2u32 == 3u32)
    return true
```
causes this error to be thrown
```
Error: Const assert failed: (no error message given) at
    assert(2u32 == 3u32)
; context:
    assert(2u32 == 3u32)
```

whereas this essentially identical program does not

```
def main() -> bool: 
    u32 x = 2
    assert(x == 3)
    return true
```
(instead circ happily generates a circuit that always returns false)

Needless to say this can make debugging difficult. Luckily, I believe fixing this is a one line change. The culprit seems to be here: https://github.com/circify/circ/blob/2b54efa5a48dc09804e19761721b2bcd06d56050/src/front/zsharp/mod.rs#L1254

Since `expr_impl` is called with `IS_CNST = true`, it returns `Err` in the latter program since `x` is not a const variable. However, as far as I can tell, this check is unnecessary. The relevant matter is whether (after constant folding), the expression evaluates to `false` which is what the subsequent call to `const_bool` is checking anyway. Hence the solution seems to be to call `expr_impl` with `IS_CNST = false` instead.