### PR TITLE
allow partially const tuples

### DIFF
--- a/src/ir/opt/cfold.rs
+++ b/src/ir/opt/cfold.rs
@@ -40,6 +40,16 @@ fn cbv(b: BitVector) -> Option<Term> {
     Some(const_(Value::BitVector(b)))
 }
 
+/// Create a tuple from children. If all children are const, then make the whole tuple const
+fn new_tuple(children: Vec<Term>) -> Term {
+    children
+        .iter()
+        .map(|c| c.as_value_opt().cloned())
+        .collect::<Option<_>>()
+        .map(|v| const_(Value::Tuple(v)))
+        .unwrap_or(term(Op::Tuple, children))
+}
+
 /// Fold away operators over constants.
 pub fn fold(node: &Term, ignore: &[Op]) -> Term {
     FOLDS.with(|cache_handle| {
@@ -353,21 +363,31 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<TTerm>, ignore: &[Op]) -> T
                     (Some(arr), Some(idx)) => Some(const_(arr.select(idx))),
                     _ => None,
                 },
-                Op::Tuple => t
-                    .cs()
-                    .iter()
-                    .map(|c| c_get(c).as_value_opt().cloned())
-                    .collect::<Option<_>>()
-                    .map(|v| const_(Value::Tuple(v))),
-                Op::Field(n) => get(0).as_tuple_opt().map(|t| const_(t[*n].clone())),
-                Op::Update(n) => match (get(0).as_tuple_opt(), get(1).as_value_opt()) {
-                    (Some(t), Some(v)) => {
-                        let mut new_vec = Vec::from(t).into_boxed_slice();
-                        assert_eq!(new_vec[*n].sort(), v.sort());
-                        new_vec[*n] = v.clone();
-                        Some(const_(Value::Tuple(new_vec)))
+                Op::Tuple => {
+                    Some(new_tuple(t
+                            .cs()
+                            .iter()
+                            .map(c_get).collect::<Vec<_>>()))
+                },
+                Op::Field(n) => {
+                    match get(0).op() {
+                        Op::Tuple => {
+                            let term = get(0).cs()[*n].clone();
+                            Some(term.as_value_opt().cloned().map(const_).unwrap_or(term))
+                        }
+                        _ => None
                     }
-                    _ => None,
+                },
+                Op::Update(n) => {
+                    match get(0).op() {
+                        Op::Tuple => {
+                            let mut children = get(0).cs().to_vec();
+                            children[*n] = get(1).clone();
+                            Some(new_tuple(children))
+
+                        }
+                        _ => None
+                    }
                 },
                 Op::BvConcat => t
                     .cs()


### PR DESCRIPTION
Currently, the following program fails to compile:

```
struct X {
    u32 a
    u32 b
}

def foo<A>() -> u32:
    return A

def main(u32 a) -> u32:
    X x = X {a: a, b: 12}
    u32 xb = x.b
    return foo::<xb>()
```

Even though `x.b` is conceptually a const value, the way constant folding works at present makes it so the entire tuple is const or it isn't and since `x.a` is not const, `x` is not const. This makes a very useful paradigm of creating values that are "tagged" with e.g. their bit width for the purpose of range checking infeasible. This PR aims to change that.

I do want to flag that the fundamental difficulty here (and why it wasn't implemented this way in the first place) is that the constant folding optimization relies on turning a Term into a Value and then calling `eval_op` to do the evaluation. For "partially-const" tuples, there is no such corresponding `Value`, so the constant folding code ends up duplicating some logic that is in `eval_op` (adapting it to work on `Term`s instead). For tuples this logic is pretty minimal, but for arrays it was less so which is why I did not implement an analogous fix for arrays, even though it would be nice to have that as well.

I'm not sure what the "cleanest" way to unify these are (maybe one could introduce a temporary `Value::Phantom` used only in the constant folding optimization to represent the non-const children of a `Value::Tuple`? or maybe this is overengineering and I should just duplicate the array evaluation code on `Term`s).