### PR TITLE
reduce traversal memory usage through iterators

### DIFF
--- a/examples/datalog/parse_test/one_rule.pl
+++ b/examples/datalog/parse_test/one_rule.pl
@@ -1,4 +1,4 @@
-non_zero(Z: field) :- ((Z + Y) + Y) + ~!-Y + to_field(Y);
+main(Z: field) :- ((Z + Y) + Y) + ~!-Y + to_field(Y);
                       Z;
                       exists A: field. A * Z = 1;
                       exists B: field, C: bool. B * C * Z = 4.

--- a/examples/zxc.rs
+++ b/examples/zxc.rs
@@ -140,7 +140,7 @@ fn main() {
         );
         reduce_linearities(r1cs, cfg())
     };
-    println!("Final R1cs size: {}", r1cs.constraints().len());
+    println!("Final r1cs: {} constraints", r1cs.constraints().len());
     match action {
         ProofAction::Count => {
             if !options.quiet {

--- a/scripts/ram_test.zsh
+++ b/scripts/ram_test.zsh
@@ -55,7 +55,7 @@ function cs_count_test {
     cs_upper_bound=$2
     rm -rf P V pi
     output=$($BIN $ex_name r1cs --action count |& cat)
-    n_constraints=$(echo "$output" | grep 'Final r1cs: \d+' -o | grep -Eo '\b[0-9]+\b')
+    n_constraints=$(echo "$output" | grep -E 'Final r1cs: [0-9]+' -o | grep -Eo '\b[0-9]+\b')
     [[ $n_constraints -lt $cs_upper_bound ]] || (echo "Got $n_constraints, expected < $cs_upper_bound" && exit 1)
 }
 

--- a/scripts/ram_test.zsh
+++ b/scripts/ram_test.zsh
@@ -55,7 +55,7 @@ function cs_count_test {
     cs_upper_bound=$2
     rm -rf P V pi
     output=$($BIN $ex_name r1cs --action count |& cat)
-    n_constraints=$(echo "$output" | grep 'Final R1cs size:' | grep -Eo '\b[0-9]+\b')
+    n_constraints=$(echo "$output" | grep 'Final r1cs: \d+' -o | grep -Eo '\b[0-9]+\b')
     [[ $n_constraints -lt $cs_upper_bound ]] || (echo "Got $n_constraints, expected < $cs_upper_bound" && exit 1)
 }
 

--- a/scripts/spartan_zok_test.zsh
+++ b/scripts/spartan_zok_test.zsh
@@ -28,7 +28,7 @@ function r1cs_test_count {
     zpath=$1
     threshold=$2
     o=$($BIN --field-custom-modulus $modulus $zpath r1cs --action count)
-    n_constraints=$(echo $o | grep 'Final R1cs size:' | grep -Eo '\b[0-9]+\b')
+    n_constraints=$(echo $o | grep 'Final r1cs: \d+' -o | grep -Eo '\b[0-9]+\b')
     [[ $n_constraints -lt $threshold ]] || (echo "Got $n_constraints, expected < $threshold" && exit 1)
 }
 

--- a/scripts/spartan_zok_test.zsh
+++ b/scripts/spartan_zok_test.zsh
@@ -28,7 +28,7 @@ function r1cs_test_count {
     zpath=$1
     threshold=$2
     o=$($BIN --field-custom-modulus $modulus $zpath r1cs --action count)
-    n_constraints=$(echo $o | grep 'Final r1cs: \d+' -o | grep -Eo '\b[0-9]+\b')
+    n_constraints=$(echo $o | grep -E 'Final r1cs: [0-9]+' -o | grep -Eo '\b[0-9]+\b')
     [[ $n_constraints -lt $threshold ]] || (echo "Got $n_constraints, expected < $threshold" && exit 1)
 }
 

--- a/scripts/test_datalog.zsh
+++ b/scripts/test_datalog.zsh
@@ -9,16 +9,21 @@ BIN=./target/debug/examples/circ
 $BIN --language datalog ./examples/datalog/inv.pl r1cs --action count || true
 $BIN --language datalog ./examples/datalog/call.pl r1cs --action count || true
 $BIN --language datalog ./examples/datalog/arr.pl r1cs --action count || true
+
+function getconstraints {
+    grep -E "Final r1cs: .* constraints" -o |  grep -E -o "\\b[0-9]+"
+}
+
 # Small R1cs b/c too little recursion.
-size=$(($BIN --language datalog ./examples/datalog/dumb_hash.pl --datalog-rec-limit 4 r1cs --action count || true) |  grep -E "Final R1cs size:" |  grep -E -o "\\b[0-9]+")
+size=$(($BIN --language datalog ./examples/datalog/dumb_hash.pl --datalog-rec-limit 4 r1cs --action count || true) | getconstraints)
 [ "$size" -lt 10 ]
 
 # Big R1cs b/c enough recursion
-size=$(($BIN --language datalog ./examples/datalog/dumb_hash.pl --datalog-rec-limit 5 r1cs --action count || true) |  grep -E "Final R1cs size:" |  grep -E -o "\\b[0-9]+")
+size=$(($BIN --language datalog ./examples/datalog/dumb_hash.pl --datalog-rec-limit 5 r1cs --action count || true) | getconstraints)
 [ "$size" -gt 250 ]
-size=$(($BIN --language datalog ./examples/datalog/dumb_hash.pl --datalog-rec-limit 10 r1cs --action count || true) |  grep -E "Final R1cs size:" |  grep -E -o "\\b[0-9]+")
+size=$(($BIN --language datalog ./examples/datalog/dumb_hash.pl --datalog-rec-limit 10 r1cs --action count || true) | getconstraints)
 [ "$size" -gt 250 ]
-size=$(($BIN --language datalog ./examples/datalog/dec.pl --datalog-rec-limit 2 r1cs --action count || true) |  grep -E "Final R1cs size:" |  grep -E -o "\\b[0-9]+")
+size=$(($BIN --language datalog ./examples/datalog/dec.pl --datalog-rec-limit 2 r1cs --action count || true) | getconstraints)
 [ "$size" -gt 250 ]
 
 # Test prim-rec test

--- a/scripts/test_datalog.zsh
+++ b/scripts/test_datalog.zsh
@@ -6,7 +6,6 @@ disable -r time
 
 BIN=./target/debug/examples/circ
 
-$BIN --language datalog ./examples/datalog/parse_test/one_rule.pl r1cs --action count || true
 $BIN --language datalog ./examples/datalog/inv.pl r1cs --action count || true
 $BIN --language datalog ./examples/datalog/call.pl r1cs --action count || true
 $BIN --language datalog ./examples/datalog/arr.pl r1cs --action count || true

--- a/scripts/zokrates_test.zsh
+++ b/scripts/zokrates_test.zsh
@@ -29,7 +29,7 @@ function r1cs_test_count {
     zpath=$1
     threshold=$2
     o=$($BIN $zpath r1cs --action count)
-    n_constraints=$(echo $o | grep 'Final r1cs: \d+' -o | grep -Eo '\b[0-9]+\b')
+    n_constraints=$(echo $o | grep -E 'Final r1cs: [0-9]+' -o | grep -Eo '\b[0-9]+\b')
     [[ $n_constraints -lt $threshold ]] || (echo "Got $n_constraints, expected < $threshold" && exit 1)
 }
 

--- a/scripts/zokrates_test.zsh
+++ b/scripts/zokrates_test.zsh
@@ -29,7 +29,7 @@ function r1cs_test_count {
     zpath=$1
     threshold=$2
     o=$($BIN $zpath r1cs --action count)
-    n_constraints=$(echo $o | grep 'Final R1cs size:' | grep -Eo '\b[0-9]+\b')
+    n_constraints=$(echo $o | grep 'Final r1cs: \d+' -o | grep -Eo '\b[0-9]+\b')
     [[ $n_constraints -lt $threshold ]] || (echo "Got $n_constraints, expected < $threshold" && exit 1)
 }
 

--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -772,11 +772,10 @@ impl<'ast> ZGen<'ast> {
                 f_path.clone(),
                 f_name.clone(),
             )
-            .map(|v| {
+            .inspect(|v| {
                 self.fn_call_memoization
                     .borrow_mut()
                     .insert(input, v.clone());
-                v
             })
         };
         let dur = (time::Instant::now() - before).as_millis();

--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -1277,7 +1277,7 @@ impl<'ast> ZGen<'ast> {
         match e {
             ast::Expression::Ternary(u) => {
                 match self
-                    .expr_impl_::<false>(&u.first)
+                    .expr_impl_::<IS_CNST>(&u.first)
                     .ok()
                     .and_then(const_bool_simple)
                 {
@@ -1452,8 +1452,8 @@ impl<'ast> ZGen<'ast> {
                 .map_err(|e| format!("{e}"))
             }
             ast::Statement::Assertion(e) => {
-                let expr = self.expr_impl_::<false>(&e.expression);
-                match expr.clone().ok().and_then(const_bool_simple) {
+                let expr = self.expr_impl_::<IS_CNST>(&e.expression)?;
+                match const_bool_simple(expr.clone()) {
                     Some(true) => Ok(()),
                     Some(false) => Err(format!(
                         "Const assert failed: {} at\n{}",
@@ -1464,11 +1464,11 @@ impl<'ast> ZGen<'ast> {
                         span_to_string(e.expression.span()),
                     )),
                     None if IS_CNST => Err(format!(
-                        "Const assert expression eval failed at\n{}",
+                        "Const assert failed (non-const expression) at\n{}",
                         span_to_string(e.expression.span()),
                     )),
                     _ => {
-                        let b = bool(expr?)?;
+                        let b = bool(expr)?;
                         self.assert(b)?;
                         Ok(())
                     }

--- a/src/front/zsharp/term.rs
+++ b/src/front/zsharp/term.rs
@@ -226,8 +226,8 @@ impl T {
     }
 
     pub fn new_integer<I>(v: I) -> Self
-    where 
-        Integer: From<I>
+    where
+        Integer: From<I>,
     {
         T::new(Ty::Integer, int_lit(v))
     }
@@ -335,7 +335,7 @@ fn wrap_bin_pred(
     b: T,
 ) -> Result<T, String> {
     match (&a.ty, &b.ty, fu, ff, fb, fi) {
-        (Ty::Uint(na), Ty::Uint(nb), Some(fu), _, _,_) if na == nb => {
+        (Ty::Uint(na), Ty::Uint(nb), Some(fu), _, _, _) if na == nb => {
             Ok(T::new(Ty::Bool, fu(a.term.clone(), b.term.clone())))
         }
         (Ty::Bool, Ty::Bool, _, _, Some(fb), _) => {
@@ -364,7 +364,15 @@ fn add_integer(a: Term, b: Term) -> Term {
 }
 
 pub fn add(a: T, b: T) -> Result<T, String> {
-    wrap_bin_op("+", Some(add_uint), Some(add_field), None, Some(add_integer), a, b)
+    wrap_bin_op(
+        "+",
+        Some(add_uint),
+        Some(add_field),
+        None,
+        Some(add_integer),
+        a,
+        b,
+    )
 }
 
 fn sub_uint(a: Term, b: Term) -> Term {
@@ -380,7 +388,15 @@ fn sub_integer(a: Term, b: Term) -> Term {
 }
 
 pub fn sub(a: T, b: T) -> Result<T, String> {
-    wrap_bin_op("-", Some(sub_uint), Some(sub_field), None, Some(sub_integer), a, b)
+    wrap_bin_op(
+        "-",
+        Some(sub_uint),
+        Some(sub_field),
+        None,
+        Some(sub_integer),
+        a,
+        b,
+    )
 }
 
 fn mul_uint(a: Term, b: Term) -> Term {
@@ -396,7 +412,15 @@ fn mul_integer(a: Term, b: Term) -> Term {
 }
 
 pub fn mul(a: T, b: T) -> Result<T, String> {
-    wrap_bin_op("*", Some(mul_uint), Some(mul_field), None, Some(mul_integer), a, b)
+    wrap_bin_op(
+        "*",
+        Some(mul_uint),
+        Some(mul_field),
+        None,
+        Some(mul_integer),
+        a,
+        b,
+    )
 }
 
 fn div_uint(a: Term, b: Term) -> Term {
@@ -412,7 +436,15 @@ fn div_integer(a: Term, b: Term) -> Term {
 }
 
 pub fn div(a: T, b: T) -> Result<T, String> {
-    wrap_bin_op("/", Some(div_uint), Some(div_field), None, Some(div_integer), a, b)
+    wrap_bin_op(
+        "/",
+        Some(div_uint),
+        Some(div_field),
+        None,
+        Some(div_integer),
+        a,
+        b,
+    )
 }
 
 fn to_dflt_f(t: Term) -> Term {
@@ -435,7 +467,15 @@ fn rem_integer(a: Term, b: Term) -> Term {
 }
 
 pub fn rem(a: T, b: T) -> Result<T, String> {
-    wrap_bin_op("%", Some(rem_uint), Some(rem_field), None, Some(rem_integer), a, b)
+    wrap_bin_op(
+        "%",
+        Some(rem_uint),
+        Some(rem_field),
+        None,
+        Some(rem_integer),
+        a,
+        b,
+    )
 }
 
 fn bitand_uint(a: Term, b: Term) -> Term {
@@ -515,12 +555,20 @@ fn ult_field(a: Term, b: Term) -> Term {
     field_comp(a, b, BvBinPred::Ult)
 }
 
-fn ult_integer(a: Term, b:Term) -> Term {
+fn ult_integer(a: Term, b: Term) -> Term {
     term![Op::IntBinPred(IntBinPred::Lt); a,b]
 }
 
 pub fn ult(a: T, b: T) -> Result<T, String> {
-    wrap_bin_pred("<", Some(ult_uint), Some(ult_field), None, Some(ult_integer), a, b)
+    wrap_bin_pred(
+        "<",
+        Some(ult_uint),
+        Some(ult_field),
+        None,
+        Some(ult_integer),
+        a,
+        b,
+    )
 }
 
 fn ule_uint(a: Term, b: Term) -> Term {
@@ -531,12 +579,20 @@ fn ule_field(a: Term, b: Term) -> Term {
     field_comp(a, b, BvBinPred::Ule)
 }
 
-fn ule_integer(a: Term, b:Term) -> Term {
+fn ule_integer(a: Term, b: Term) -> Term {
     term![Op::IntBinPred(IntBinPred::Le); a, b]
 }
 
 pub fn ule(a: T, b: T) -> Result<T, String> {
-    wrap_bin_pred("<=", Some(ule_uint), Some(ule_field), None, Some(ule_integer), a, b)
+    wrap_bin_pred(
+        "<=",
+        Some(ule_uint),
+        Some(ule_field),
+        None,
+        Some(ule_integer),
+        a,
+        b,
+    )
 }
 
 fn ugt_uint(a: Term, b: Term) -> Term {
@@ -552,7 +608,15 @@ fn ugt_integer(a: Term, b: Term) -> Term {
 }
 
 pub fn ugt(a: T, b: T) -> Result<T, String> {
-    wrap_bin_pred(">", Some(ugt_uint), Some(ugt_field), None, Some(ugt_integer), a, b)
+    wrap_bin_pred(
+        ">",
+        Some(ugt_uint),
+        Some(ugt_field),
+        None,
+        Some(ugt_integer),
+        a,
+        b,
+    )
 }
 
 fn uge_uint(a: Term, b: Term) -> Term {
@@ -568,18 +632,31 @@ fn uge_integer(a: Term, b: Term) -> Term {
 }
 
 pub fn uge(a: T, b: T) -> Result<T, String> {
-    wrap_bin_pred(">=", Some(uge_uint), Some(uge_field), None, Some(uge_integer), a, b)
+    wrap_bin_pred(
+        ">=",
+        Some(uge_uint),
+        Some(uge_field),
+        None,
+        Some(uge_integer),
+        a,
+        b,
+    )
 }
-
 
 pub fn pow(a: T, b: T) -> Result<T, String> {
     if (a.ty != Ty::Field && a.ty != Ty::Integer) || b.ty != Ty::Uint(32) {
-        return Err(format!("Cannot compute {a} ** {b} : must be Field/Integer ** U32"));
+        return Err(format!(
+            "Cannot compute {a} ** {b} : must be Field/Integer ** U32"
+        ));
     }
 
     let b = const_int(b)?;
     if b == 0 {
-        return Ok((if a.ty == Ty::Field {T::new_field} else {T::new_integer})(1))
+        return Ok((if a.ty == Ty::Field {
+            T::new_field
+        } else {
+            T::new_integer
+        })(1));
     }
 
     Ok((0..b.significant_bits() - 1)
@@ -625,7 +702,14 @@ fn neg_integer(a: Term) -> Term {
 
 // Missing from ZoKrates.
 pub fn neg(a: T) -> Result<T, String> {
-    wrap_un_op("unary-", Some(neg_uint), Some(neg_field), None, Some(neg_integer), a)
+    wrap_un_op(
+        "unary-",
+        Some(neg_uint),
+        Some(neg_field),
+        None,
+        Some(neg_integer),
+        a,
+    )
 }
 
 fn not_bool(a: Term) -> Term {
@@ -658,7 +742,7 @@ pub fn const_bool(a: T) -> Option<bool> {
 
 pub fn const_fold(t: T) -> T {
     let folded = constant_fold(&t.term, &[]);
-    return T::new(t.ty, folded)
+    T::new(t.ty, folded)
 }
 
 pub fn const_val(a: T) -> Result<T, String> {
@@ -742,7 +826,6 @@ where
 {
     T::new(Ty::Uint(bits), bv_lit(v, bits))
 }
-
 
 pub fn slice(arr: T, start: Option<usize>, end: Option<usize>) -> Result<T, String> {
     match &arr.ty {
@@ -893,7 +976,10 @@ pub fn uint_to_field(u: T) -> Result<T, String> {
 
 pub fn integer_to_field(u: T) -> Result<T, String> {
     match &u.ty {
-        Ty::Integer => Ok(T::new(Ty::Field, term![Op::IntToPf(default_field()); u.term])),
+        Ty::Integer => Ok(T::new(
+            Ty::Field,
+            term![Op::IntToPf(default_field()); u.term],
+        )),
         u => Err(format!("Cannot do int-to-field on {u}")),
     }
 }
@@ -905,8 +991,7 @@ pub fn field_to_integer(u: T) -> Result<T, String> {
     }
 }
 
-
-pub fn int_to_bits(i: T, n: usize) -> Result<T,String> {
+pub fn int_to_bits(i: T, n: usize) -> Result<T, String> {
     match &i.ty {
         Ty::Integer => uint_to_bits(T::new(Ty::Uint(n), term![Op::IntToBv(n); i.term])),
         u => Err(format!("Cannot do uint-to-bits on {u}")),
@@ -922,7 +1007,10 @@ pub fn int_size(i: T) -> Result<T, String> {
 
 pub fn int_modinv(i: T, m: T) -> Result<T, String> {
     match (&i.ty, &m.ty) {
-        (Ty::Integer, Ty::Integer) => Ok(T::new(Ty::Integer, term![Op::IntBinOp(IntBinOp::ModInv); i.term, m.term])),
+        (Ty::Integer, Ty::Integer) => Ok(T::new(
+            Ty::Integer,
+            term![Op::IntBinOp(IntBinOp::ModInv); i.term, m.term],
+        )),
         u => Err(format!("Cannot do modinv on {:?}", u)),
     }
 }

--- a/src/front/zsharp/zvisit/zstmtwalker/mod.rs
+++ b/src/front/zsharp/zvisit/zstmtwalker/mod.rs
@@ -414,7 +414,9 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
             },
             Pow => match &bt {
                 // XXX does POW operator really require U32 RHS?
-                Field(_) | Integer(_) => Ok((Basic(bt), Basic(U32(ast::U32Type { span: be.span })))),
+                Field(_) | Integer(_) => {
+                    Ok((Basic(bt), Basic(U32(ast::U32Type { span: be.span }))))
+                }
                 _ => Err(ZVisitorError(
                     "ZStatementWalker: pow operator must take Field LHS and U32 RHS".to_owned(),
                 )),

--- a/src/front/zsharp/zvisit/zstmtwalker/zexprtyper.rs
+++ b/src/front/zsharp/zvisit/zstmtwalker/zexprtyper.rs
@@ -204,7 +204,9 @@ impl<'ast, 'ret, 'wlk> ZVisitorMut<'ast> for ZExpressionTyper<'ast, 'ret, 'wlk> 
             DS::Field(s) => self
                 .ty
                 .replace(Basic(Field(ast::FieldType { span: s.span }))),
-            DS::Integer(s) => self.ty.replace(Basic(Integer(ast::IntegerType {span: s.span }))),
+            DS::Integer(s) => self
+                .ty
+                .replace(Basic(Integer(ast::IntegerType { span: s.span }))),
         };
         Ok(())
     }

--- a/src/ir/opt/cfold.rs
+++ b/src/ir/opt/cfold.rs
@@ -363,34 +363,26 @@ pub fn fold_cache(node: &Term, cache: &mut TermCache<TTerm>, ignore: &[Op]) -> T
                     (Some(arr), Some(idx)) => Some(const_(arr.select(idx))),
                     _ => None,
                 },
-                Op::Tuple => {
-                    Some(new_tuple(t
-                            .cs()
-                            .iter()
-                            .map(c_get).collect::<Vec<_>>()))
-                },
-                Op::Field(n) => {
-                    match get(0).op() {
-                        Op::Tuple => {
-                            let term = get(0).cs()[*n].clone();
-                            Some(term.as_value_opt()
+                Op::Tuple => Some(new_tuple(t.cs().iter().map(c_get).collect::<Vec<_>>())),
+                Op::Field(n) => match get(0).op() {
+                    Op::Tuple => {
+                        let term = get(0).cs()[*n].clone();
+                        Some(
+                            term.as_value_opt()
                                 .cloned()
                                 .map(|t| leaf_term(Op::new_const(t)))
-                                .unwrap_or(term))
-                        }
-                        _ => None
+                                .unwrap_or(term),
+                        )
                     }
+                    _ => None,
                 },
-                Op::Update(n) => {
-                    match get(0).op() {
-                        Op::Tuple => {
-                            let mut children = get(0).cs().to_vec();
-                            children[*n] = get(1).clone();
-                            Some(new_tuple(children))
-
-                        }
-                        _ => None
+                Op::Update(n) => match get(0).op() {
+                    Op::Tuple => {
+                        let mut children = get(0).cs().to_vec();
+                        children[*n] = get(1).clone();
+                        Some(new_tuple(children))
                     }
+                    _ => None,
                 },
                 Op::BvConcat => t
                     .cs()

--- a/src/target/r1cs/mod.rs
+++ b/src/target/r1cs/mod.rs
@@ -443,12 +443,12 @@ impl R1cs {
         let s = &mut self.stats;
         s.n_constraints = self.constraints.len() as u32;
         for (a, b, c) in &self.constraints {
-            let n_a = a.monomials.len() + !a.constant.is_zero() as usize;
-            let n_b = b.monomials.len() + !b.constant.is_zero() as usize;
-            let n_c = c.monomials.len() + !c.constant.is_zero() as usize;
-            s.n_a_entries += n_a as u32;
-            s.n_b_entries += n_b as u32;
-            s.n_c_entries += n_c as u32;
+            let n_a = a.monomials.len() as u32 + !a.constant.is_zero() as u32;
+            let n_b = b.monomials.len() as u32 + !b.constant.is_zero() as u32;
+            let n_c = c.monomials.len() as u32 + !c.constant.is_zero() as u32;
+            s.n_a_entries += n_a;
+            s.n_b_entries += n_b;
+            s.n_c_entries += n_c;
         }
     }
 }

--- a/src/util/once.rs
+++ b/src/util/once.rs
@@ -29,9 +29,8 @@ impl<T: Eq + Hash + Clone> OnceQueue<T> {
     }
     /// Remove the oldest element from the queue.
     pub fn pop(&mut self) -> Option<T> {
-        self.queue.pop_front().map(|t| {
-            self.set.remove(&t);
-            t
+        self.queue.pop_front().inspect(|t| {
+            self.set.remove(t);
         })
     }
     /// Make an empty queue.

--- a/third_party/ZoKrates/zokrates_pest_ast/src/lib.rs
+++ b/third_party/ZoKrates/zokrates_pest_ast/src/lib.rs
@@ -16,14 +16,15 @@ pub use ast::{
     Expression, FieldSuffix, FieldType, File, FromExpression, FromImportDirective,
     FunctionDefinition, HexLiteralExpression, HexNumberExpression, IdentifierExpression,
     ImportDirective, ImportSymbol, InlineArrayExpression, InlineStructExpression,
-    InlineStructMember, IterationStatement, LiteralExpression, MainImportDirective, MemberAccess,
-    NegOperator, NotOperator, Parameter, PosOperator, PostfixExpression, Pragma, PrivateNumber,
-    PrivateVisibility, PublicVisibility, Range, RangeOrExpression, ReturnStatement, Span, Spread,
-    SpreadOrExpression, Statement, StrOperator, StructDefinition, StructField, StructType,
-    SymbolDeclaration, TernaryExpression, ToExpression, Type, TypeDefinition, TypedIdentifier,
-    TypedIdentifierOrAssignee, U16NumberExpression, U16Suffix, U16Type, U32NumberExpression,
-    U32Suffix, U32Type, IntegerSuffix, IntegerType, U64NumberExpression, U64Suffix, U64Type, U8NumberExpression, U8Suffix,
-    U8Type, UnaryExpression, UnaryOperator, Underscore, Visibility, WitnessStatement, EOI,
+    InlineStructMember, IntegerSuffix, IntegerType, IterationStatement, LiteralExpression,
+    MainImportDirective, MemberAccess, NegOperator, NotOperator, Parameter, PosOperator,
+    PostfixExpression, Pragma, PrivateNumber, PrivateVisibility, PublicVisibility, Range,
+    RangeOrExpression, ReturnStatement, Span, Spread, SpreadOrExpression, Statement, StrOperator,
+    StructDefinition, StructField, StructType, SymbolDeclaration, TernaryExpression, ToExpression,
+    Type, TypeDefinition, TypedIdentifier, TypedIdentifierOrAssignee, U16NumberExpression,
+    U16Suffix, U16Type, U32NumberExpression, U32Suffix, U32Type, U64NumberExpression, U64Suffix,
+    U64Type, U8NumberExpression, U8Suffix, U8Type, UnaryExpression, UnaryOperator, Underscore,
+    Visibility, WitnessStatement, EOI,
 };
 
 mod ast {
@@ -271,7 +272,7 @@ mod ast {
         U16(U16Type<'ast>),
         U32(U32Type<'ast>),
         U64(U64Type<'ast>),
-        Integer(IntegerType<'ast>)
+        Integer(IntegerType<'ast>),
     }
 
     #[derive(Debug, FromPest, PartialEq, Clone)]
@@ -955,7 +956,7 @@ mod ast {
         U32(U32Suffix<'ast>),
         U64(U64Suffix<'ast>),
         Field(FieldSuffix<'ast>),
-        Integer(IntegerSuffix<'ast>)
+        Integer(IntegerSuffix<'ast>),
     }
 
     #[derive(Debug, FromPest, PartialEq, Clone)]


### PR DESCRIPTION
Previously, the traversal stack held (node, children queued) pairs.
When visiting a node without it's children queued, we would queue them
all. They take a lot of memory!

Now, the stack holds children iterators.