### PR TITLE
make the changes suggested by the compiler to make the rust linter happy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ scripts/aby_tests/tests
 /flamegraph*.svg
 /.ccls-cache
 /.vscode
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ scripts/aby_tests/tests
 /flamegraph*.svg
 /.ccls-cache
 /.vscode
-CLAUDE.md

--- a/circ_fields/src/lib.rs
+++ b/circ_fields/src/lib.rs
@@ -314,7 +314,7 @@ impl FieldV {
         let ptr: *const FullFieldV = self.0 as *const _;
         unsafe { &*ptr }
     }
-    fn full_cow(&self) -> std::borrow::Cow<FullFieldV> {
+    fn full_cow(&self) -> std::borrow::Cow<'_, FullFieldV> {
         if self.is_full() {
             std::borrow::Cow::Borrowed(self.full_ref())
         } else {

--- a/src/front/datalog/mod.rs
+++ b/src/front/datalog/mod.rs
@@ -113,7 +113,7 @@ impl<'ast> Gen<'ast> {
         )
     }
 
-    fn entry_rule(&mut self, name: &'ast str) -> Result<()> {
+    fn entry_rule(&mut self, name: &'ast str) -> Result<'_, ()> {
         let rule = *self
             .rules
             .get(name)
@@ -291,7 +291,7 @@ impl<'ast> Gen<'ast> {
     }
 
     // Begin prim-rec linting
-    fn lint_rules(&mut self) -> Result<()> {
+    fn lint_rules(&mut self) -> Result<'_, ()> {
         let rules: Vec<&'ast ast::Rule_> = self.rules.values().cloned().collect();
         let bug_if = rules.iter().try_fold(term::bool_lit(false), |x, rule| {
             let cond = self.lint_rule(rule)?;

--- a/src/front/datalog/parser.rs
+++ b/src/front/datalog/parser.rs
@@ -24,7 +24,7 @@ pub mod ast {
     pub use pest::Span;
     use pest_ast::FromPest;
 
-    fn span_into_str(span: Span) -> &str {
+    fn span_into_str(span: Span<'_>) -> &str {
         span.as_str()
     }
 
@@ -534,7 +534,7 @@ pub mod ast {
 }
 
 #[allow(clippy::result_large_err)]
-pub fn parse(file_string: &str) -> Result<ast::Program, Error<Rule>> {
+pub fn parse(file_string: &str) -> Result<ast::Program<'_>, Error<Rule>> {
     let mut pest_pairs = MyParser::parse(Rule::program, file_string)?;
     use from_pest::FromPest;
     Ok(ast::Program::from_pest(&mut pest_pairs).expect("bug in AST construction"))

--- a/src/front/zsharp/parser.rs
+++ b/src/front/zsharp/parser.rs
@@ -106,7 +106,7 @@ impl ZLoad {
     /// ## Returns
     ///
     /// Returns a map from file paths to parsed files.
-    pub fn load<P: AsRef<Path>>(&self, p: &P) -> HashMap<PathBuf, ast::File> {
+    pub fn load<P: AsRef<Path>>(&self, p: &P) -> HashMap<PathBuf, ast::File<'_>> {
         self.recursive_load(p).unwrap()
     }
 

--- a/src/front/zsharpcurly/parser.rs
+++ b/src/front/zsharpcurly/parser.rs
@@ -106,7 +106,7 @@ impl ZLoad {
     /// ## Returns
     ///
     /// Returns a map from file paths to parsed files.
-    pub fn load<P: AsRef<Path>>(&self, p: &P) -> HashMap<PathBuf, ast::File> {
+    pub fn load<P: AsRef<Path>>(&self, p: &P) -> HashMap<PathBuf, ast::File<'_>> {
         self.recursive_load(p).unwrap()
     }
 

--- a/src/ir/term/bv.rs
+++ b/src/ir/term/bv.rs
@@ -253,7 +253,7 @@ impl BitVector {
 
 impl Display for BitVector {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        if self.width % 4 == 0 {
+        if self.width.is_multiple_of(4) {
             write!(
                 f,
                 "#x{:0>width$}",

--- a/src/ir/term/fmt.rs
+++ b/src/ir/term/fmt.rs
@@ -228,7 +228,7 @@ pub struct IrWrapper<'a, T> {
 }
 
 /// Wrap a reference for IR formatting. Uses [IrCfg::from_circ_cfg].
-pub fn wrap<T>(t: &T) -> IrWrapper<T> {
+pub fn wrap<T>(t: &T) -> IrWrapper<'_, T> {
     IrWrapper::new(t, IrCfg::from_circ_cfg())
 }
 

--- a/src/ir/term/mod.rs
+++ b/src/ir/term/mod.rs
@@ -819,7 +819,7 @@ impl std::hash::Hash for Value {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Default)]
 /// The "type" of an IR term
 pub enum Sort {
     /// bit-vectors of this width
@@ -833,6 +833,7 @@ pub enum Sort {
     /// prime field, integers mod FieldT.modulus()
     Field(FieldT),
     /// boolean
+    #[default]
     Bool,
     /// Array from one sort to another, of fixed size.
     ///
@@ -862,12 +863,6 @@ pub struct MapSort {
     pub key: Sort,
     /// value sort
     pub val: Sort,
-}
-
-impl Default for Sort {
-    fn default() -> Self {
-        Self::Bool
-    }
 }
 
 impl Sort {

--- a/src/ir/term/text/mod.rs
+++ b/src/ir/term/text/mod.rs
@@ -125,7 +125,7 @@ impl Debug for TokTree<'_> {
 }
 
 /// Parse a token tree.
-fn parse_tok_tree(bytes: &[u8]) -> TokTree {
+fn parse_tok_tree(bytes: &[u8]) -> TokTree<'_> {
     let mut stack: Vec<Vec<TokTree>> = vec![vec![]];
     let lex = Token::lexer(bytes).spanned();
     for (t, s) in lex {

--- a/third_party/ZoKrates/zokrates_parser/src/lib.rs
+++ b/third_party/ZoKrates/zokrates_parser/src/lib.rs
@@ -12,7 +12,7 @@ use pest::Parser;
 #[grammar = "zokrates.pest"]
 struct ZoKratesParser;
 
-pub fn parse(input: &str) -> Result<Pairs<Rule>, Error<Rule>> {
+pub fn parse(input: &str) -> Result<Pairs<'_, Rule>, Error<Rule>> {
     ZoKratesParser::parse(Rule::file, input)
 }
 

--- a/third_party/ZoKrates/zokrates_pest_ast/src/lib.rs
+++ b/third_party/ZoKrates/zokrates_pest_ast/src/lib.rs
@@ -1124,7 +1124,7 @@ impl fmt::Display for Error {
     }
 }
 
-pub fn generate_ast(input: &str) -> Result<ast::File, Error> {
+pub fn generate_ast(input: &str) -> Result<ast::File<'_>, Error> {
     let parse_tree = parse(input).map_err(Error)?;
     Ok(Prog::from(parse_tree).0)
 }

--- a/third_party/ZoKratesCurly/zokrates_parser/src/lib.rs
+++ b/third_party/ZoKratesCurly/zokrates_parser/src/lib.rs
@@ -13,7 +13,7 @@ use pest::Parser;
 struct ZoKratesParser;
 
 #[allow(clippy::result_large_err)]
-pub fn parse(input: &str) -> Result<Pairs<Rule>, Error<Rule>> {
+pub fn parse(input: &str) -> Result<Pairs<'_, Rule>, Error<Rule>> {
     ZoKratesParser::parse(Rule::file, input)
 }
 

--- a/third_party/ZoKratesCurly/zokrates_pest_ast/src/lib.rs
+++ b/third_party/ZoKratesCurly/zokrates_pest_ast/src/lib.rs
@@ -1194,7 +1194,7 @@ impl fmt::Display for Error {
 }
 
 #[allow(clippy::result_large_err)]
-pub fn generate_ast(input: &str) -> Result<ast::File, Error> {
+pub fn generate_ast(input: &str) -> Result<ast::File<'_>, Error> {
     let parse_tree = parse(input).map_err(Error)?;
     Ok(Prog::from(parse_tree).0)
 }


### PR DESCRIPTION
When I tried to follow the quickstart instructions, circ would not build because of some rust linter errors. I followed the compiler's suggestions about how to fix it, and now it builds. This resolves #235 .