### PR TITLE
frontend and ir optimizations

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -147,10 +147,8 @@ def build(features):
     install(features)
 
     cmd = ["cargo", "build"]
-    if mode:
-        cmd += ["--" + mode]
-    else:
-        # default to release mode
+    if mode != "debug":
+        # debug is cargo's default; only pass --release when needed
         cmd += ["--release"]
     cmd += ["--examples"]
 
@@ -231,10 +229,8 @@ def benchmark(features):
     install(features)
 
     cmd = ["cargo", "build"]
-    if mode:
-        cmd += ["--" + mode]
-    else:
-        # default to release mode
+    if mode != "debug":
+        # debug is cargo's default; only pass --release when needed
         cmd += ["--release"]
     cmd += ["--examples"]
 

--- a/src/front/zsharpcurly/mod.rs
+++ b/src/front/zsharpcurly/mod.rs
@@ -1308,7 +1308,9 @@ impl<'ast> ZGen<'ast> {
 
     fn expr_impl_<const IS_CNST: bool>(&self, e: &ast::Expression<'ast>) -> Result<T, String> {
         self.expr_impl_inner_::<IS_CNST>(e)
-            .map(const_fold)
+            // Only fold during const evaluation; for normal paths, folding is deferred
+            // to statement boundaries to avoid O(n^2) re-traversal of the term DAG.
+            .map(|v| if IS_CNST { const_fold(v) } else { v })
             .and_then(|v| if IS_CNST { const_val_simple(v) } else { Ok(v) })
             .map_err(|err| format!("{}; context:\n{}", err, span_to_string(e.span())))
     }
@@ -1560,14 +1562,14 @@ impl<'ast> ZGen<'ast> {
         match s {
             ast::Statement::Return(r) => if let Some(e) = r.expression.as_ref() {
                 self.set_lhs_ty_ret(r);
-                let ret = self.expr_impl_::<IS_CNST>(e)?;
+                let ret = const_fold(self.expr_impl_::<IS_CNST>(e)?);
                 self.ret_impl_::<IS_CNST>(Some(ret))
             } else {
                 self.ret_impl_::<IS_CNST>(None)
             }
             .map_err(|e| format!("{e}")),
             ast::Statement::Assertion(e) => {
-                let expr = self.expr_impl_::<IS_CNST>(&e.expression)?;
+                let expr = const_fold(self.expr_impl_::<IS_CNST>(&e.expression)?);
                 match const_bool_simple(expr.clone()) {
                     Some(true) => Ok(()),
                     Some(false) => Err(format!(
@@ -1628,7 +1630,7 @@ impl<'ast> ZGen<'ast> {
             }
             ast::Statement::Definition(d) => {
                 self.set_lhs_ty_defn::<IS_CNST>(d)?;
-                let e = self.expr_impl_::<IS_CNST>(&d.expression)?;
+                let e = const_fold(self.expr_impl_::<IS_CNST>(&d.expression)?);
 
                 match &d.lhs {
                     ast::TypedIdentifierOrAssignee::Assignee(l) => {

--- a/src/ir/opt/flat.rs
+++ b/src/ir/opt/flat.rs
@@ -110,13 +110,22 @@ pub fn flatten_nary_ops_cached(term_: Term, Cache(ref mut rewritten): &mut Cache
                     None,
                 )
             }
-            _ => Entry::Term(Rc::new(term(
-                t.op().clone(),
-                t.cs()
-                    .iter()
-                    .map(|c| rewritten.get_mut(c).unwrap().as_term())
-                    .collect(),
-            ))),
+            _ => {
+                if t.cs().iter().all(|c| rewritten.get(c).and_then(|e| match e {
+                    Entry::Term(t) => Some(&**t),
+                    _ => None,
+                }) == Some(c)) {
+                    Entry::Term(Rc::new(t.clone()))
+                } else {
+                    Entry::Term(Rc::new(term(
+                        t.op().clone(),
+                        t.cs()
+                            .iter()
+                            .map(|c| rewritten.get_mut(c).unwrap().as_term())
+                            .collect(),
+                    )))
+                }
+            }
         };
         rewritten.insert(t, entry);
     }

--- a/src/ir/opt/flat.rs
+++ b/src/ir/opt/flat.rs
@@ -111,10 +111,12 @@ pub fn flatten_nary_ops_cached(term_: Term, Cache(ref mut rewritten): &mut Cache
                 )
             }
             _ => {
-                if t.cs().iter().all(|c| rewritten.get(c).and_then(|e| match e {
-                    Entry::Term(t) => Some(&**t),
-                    _ => None,
-                }) == Some(c)) {
+                if t.cs().iter().all(|c| {
+                    rewritten.get(c).and_then(|e| match e {
+                        Entry::Term(t) => Some(&**t),
+                        _ => None,
+                    }) == Some(c)
+                }) {
                     Entry::Term(Rc::new(t.clone()))
                 } else {
                     Entry::Term(Rc::new(term(

--- a/src/ir/opt/visit.rs
+++ b/src/ir/opt/visit.rs
@@ -65,14 +65,18 @@ pub trait RewritePass {
                 } else {
                     let new_t_opt = self.visit_cache(computation, &top, &cache);
                     let new_t = new_t_opt.unwrap_or_else(|| {
-                        term(
-                            top.op().clone(),
-                            top.cs()
-                                .iter()
-                                .map(|c| cache.get(c).unwrap())
-                                .cloned()
-                                .collect(),
-                        )
+                        if top.cs().iter().all(|c| cache.get(c).unwrap() == c) {
+                            top.clone()
+                        } else {
+                            term(
+                                top.op().clone(),
+                                top.cs()
+                                    .iter()
+                                    .map(|c| cache.get(c).unwrap())
+                                    .cloned()
+                                    .collect(),
+                            )
+                        }
                     });
                     cache.insert(top.clone(), new_t);
                 }


### PR DESCRIPTION
I noticed that circ was taking a really long time to compile relatively simple zokrates files. These files just had large numbers of loops and large numbers of constants. The following optimizations sped up compile-time significantly.

1. frontend - reduce calls to constant_fold to only when necessary.
2. ir - skip rebuilding a node if it is the same as it was before. If all children are unchanged, return the existing node directly instead of rebuilding it.

Drive-by: fix an issue with driver.py that incorrectly adds --debug when trying to run in debug mode.