### PR TITLE
support ROM for zsharp-curly

### DIFF
--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -81,7 +81,7 @@ impl From<CircOpt> for CircCfg {
     fn from(opt: CircOpt) -> Self {
         let field = if !opt.field.custom_modulus.is_empty() {
             let error =
-                |r: &str| panic!("The field modulus '{}' is {}", &opt.field.custom_modulus, r);
+                |r: &str| panic!("The field modulus '{}' is {}", opt.field.custom_modulus, r);
             let i = Integer::from_str_radix(&opt.field.custom_modulus, 10)
                 .unwrap_or_else(|_| error("not an integer"));
             if i.is_probably_prime(30) == rug::integer::IsPrime::No {

--- a/src/front/datalog/mod.rs
+++ b/src/front/datalog/mod.rs
@@ -318,7 +318,7 @@ impl<'ast> Gen<'ast> {
             let mut bug_in_rule_if_any = Vec::new();
             for cond in &rule.conds {
                 let mut bug_conditions = Vec::new();
-                debug!("Start case: {}", &rule.name.value);
+                debug!("Start case: {}", rule.name.value);
                 self.circ.enter_scope();
                 if let Some(decls) = cond.existential.as_ref() {
                     for d in &decls.declarations {

--- a/src/front/zsharp/mod.rs
+++ b/src/front/zsharp/mod.rs
@@ -57,7 +57,7 @@ fn const_bool_simple(t: T) -> Option<bool> {
 fn const_val_simple(a: T) -> Result<T, String> {
     match const_value_simple(&a.term) {
         Some(v) => Ok(T::new(a.ty, leaf_term(Op::new_const(v)))),
-        _ => Err(format!("{} is not a constant value", &a)),
+        _ => Err(format!("{} is not a constant value", a)),
     }
 }
 
@@ -741,9 +741,9 @@ impl<'ast> ZGen<'ast> {
         let f = self
             .functions
             .get(&f_path)
-            .ok_or_else(|| format!("No file '{:?}' attempting fn call", &f_path))?
+            .ok_or_else(|| format!("No file '{:?}' attempting fn call", f_path))?
             .get(&f_name)
-            .ok_or_else(|| format!("No function '{}' attempting fn call", &f_name))?;
+            .ok_or_else(|| format!("No function '{}' attempting fn call", f_name))?;
         let arg_tys = args.iter().map(|arg| arg.type_().clone());
         let generics = ZGenericInf::<IS_CNST>::new(self, f, &f_path, &f_name)
             .unify_generic(egv, exp_ty, arg_tys)?;
@@ -780,7 +780,7 @@ impl<'ast> ZGen<'ast> {
         };
         let dur = (time::Instant::now() - before).as_millis();
         if dur > 50 {
-            info!("{} ms to process {} {:?}", dur, &f_name, &f_path);
+            info!("{} ms to process {} {:?}", dur, f_name, f_path);
         }
         ret
     }
@@ -802,7 +802,7 @@ impl<'ast> ZGen<'ast> {
                     generics.remove(&gid.value).ok_or_else(|| {
                         format!(
                             "Failed to find generic argument {} for builtin call {}",
-                            &gid.value, &f_name,
+                            gid.value, f_name,
                         )
                     })
                 })
@@ -814,7 +814,7 @@ impl<'ast> ZGen<'ast> {
             if f.generics.len() != generics.len() {
                 return Err(format!(
                     "Wrong number of generic params calling {} (got {}, expected {})",
-                    &f.id.value,
+                    f.id.value,
                     generics.len(),
                     f.generics.len()
                 ));
@@ -822,7 +822,7 @@ impl<'ast> ZGen<'ast> {
             if f.parameters.len() != args.len() {
                 return Err(format!(
                     "Wrong nimber of arguments calling {} (got {}, expected {})",
-                    &f.id.value,
+                    f.id.value,
                     args.len(),
                     f.parameters.len()
                 ));
@@ -940,7 +940,7 @@ impl<'ast> ZGen<'ast> {
         } else {
             panic!(
                 "No function '{:?}//{}' attempting const_entry_fn",
-                &f_file, &f_name
+                f_file, f_name
             )
         }
     }
@@ -952,9 +952,9 @@ impl<'ast> ZGen<'ast> {
         let f = self
             .functions
             .get(&f_file)
-            .unwrap_or_else(|| panic!("No file '{:?}'", &f_file))
+            .unwrap_or_else(|| panic!("No file '{:?}'", f_file))
             .get(&f_name)
-            .unwrap_or_else(|| panic!("No function '{}'", &f_name))
+            .unwrap_or_else(|| panic!("No function '{}'", f_name))
             .clone();
         // XXX(unimpl) tuple returns not supported
         assert!(f.returns.len() <= 1);
@@ -1195,7 +1195,7 @@ impl<'ast> ZGen<'ast> {
             None if IS_CNST => self.cvar_lookup(&i.value).ok_or_else(|| {
                 format!(
                     "Undefined const identifier {} in {}",
-                    &i.value,
+                    i.value,
                     self.cur_path().to_string_lossy()
                 )
             }),
@@ -1204,7 +1204,7 @@ impl<'ast> ZGen<'ast> {
                 .map_err(|e| format!("{e}"))?
             {
                 Val::Term(t) => Ok(t),
-                _ => Err(format!("Non-Term identifier {}", &i.value)),
+                _ => Err(format!("Non-Term identifier {}", i.value)),
             },
         }
     }
@@ -1338,13 +1338,7 @@ impl<'ast> ZGen<'ast> {
                 assert!(!p.accesses.is_empty());
                 let (val, accs) = if let Some(ast::Access::Call(c)) = p.accesses.first() {
                     let (f_path, f_name) = self.deref_import(&p.id.value);
-                    let exp_ty = self.lhs_ty_take().and_then(|ty| {
-                        if p.accesses.len() > 1 {
-                            None
-                        } else {
-                            Some(ty)
-                        }
-                    });
+                    let exp_ty = self.lhs_ty_take().filter(|_ty| p.accesses.len() <= 1);
                     let args = c
                         .arguments
                         .expressions
@@ -1640,7 +1634,7 @@ impl<'ast> ZGen<'ast> {
                             .search(&sa.id.value)
                             .map(|r| r.1.clone())
                             .ok_or_else(|| {
-                                format!("No such member {} of struct {nm}", &sa.id.value)
+                                format!("No such member {} of struct {nm}", sa.id.value)
                             }),
                         ty => Err(format!("Attempted member access on non-Struct type {ty}")),
                     },
@@ -1783,7 +1777,7 @@ impl<'ast> ZGen<'ast> {
             .unwrap_or(false)
         {
             self.err(
-                format!("Constant {} clashes with import of same name", &c.id.value),
+                format!("Constant {} clashes with import of same name", c.id.value),
                 &c.span,
             );
         }
@@ -1816,7 +1810,7 @@ impl<'ast> ZGen<'ast> {
 
         if let Some(ast::ArrayParamMetadata::Transcript(_)) = &c.array_metadata {
             if !value.type_().is_array() {
-                self.err(format!("Non-array transcript {}", &c.id.value), &c.span);
+                self.err(format!("Non-array transcript {}", c.id.value), &c.span);
             }
             self.mark_array_as_transcript(&c.id.value, value.clone());
         }
@@ -1829,7 +1823,7 @@ impl<'ast> ZGen<'ast> {
             .insert(c.id.value.clone(), (c.ty.clone(), value))
             .is_some()
         {
-            self.err(format!("Constant {} redefined", &c.id.value), &c.span);
+            self.err(format!("Constant {} redefined", c.id.value), &c.span);
         }
     }
 
@@ -1869,7 +1863,7 @@ impl<'ast> ZGen<'ast> {
                 let (def, path) = self.get_struct_or_type(&s.id.value).ok_or_else(|| {
                     format!(
                         "No such struct {} (did you bring it into scope?)",
-                        &s.id.value
+                        s.id.value
                     )
                 })?;
                 let generics = match def {
@@ -1886,7 +1880,7 @@ impl<'ast> ZGen<'ast> {
                 if generics.len() != g_len {
                     return Err(format!(
                         "Struct {} is not monomorphized or wrong number of generic parameters",
-                        &s.id.value
+                        s.id.value
                     ));
                 }
                 self.file_stack_push(path);
@@ -2086,7 +2080,7 @@ impl<'ast> ZGen<'ast> {
                             .is_some()
                         {
                             self.err(
-                                format!("Struct {} defined over existing name", &s.id.value),
+                                format!("Struct {} defined over existing name", s.id.value),
                                 &s.span,
                             );
                         }
@@ -2111,7 +2105,7 @@ impl<'ast> ZGen<'ast> {
                             .is_some()
                         {
                             self.err(
-                                format!("Type {} defined over existing name", &t.id.value),
+                                format!("Type {} defined over existing name", t.id.value),
                                 &t.span,
                             );
                         }
@@ -2132,7 +2126,7 @@ impl<'ast> ZGen<'ast> {
                             self.err(
                                 format!(
                                     "Functions must return exactly 1 value; {} returns {}",
-                                    &f_ast.id.value,
+                                    f_ast.id.value,
                                     f_ast.returns.len(),
                                 ),
                                 &f.span,
@@ -2164,7 +2158,7 @@ impl<'ast> ZGen<'ast> {
                             .insert(f.id.value.clone(), f_ast)
                             .is_some()
                         {
-                            self.err(format!("Function {} redefined", &f.id.value), &f.span);
+                            self.err(format!("Function {} redefined", f.id.value), &f.span);
                         }
                     }
                     ast::SymbolDeclaration::Import(_) => (), // already handled in visit_imports

--- a/src/front/zsharp/term.rs
+++ b/src/front/zsharp/term.rs
@@ -779,7 +779,7 @@ pub fn const_fold(t: T) -> T {
 pub fn const_val(a: T) -> Result<T, String> {
     match const_value(&a.term) {
         Some(v) => Ok(T::new(a.ty, const_(v))),
-        _ => Err(format!("{} is not a constant value", &a)),
+        _ => Err(format!("{} is not a constant value", a)),
     }
 }
 
@@ -917,7 +917,7 @@ fn coerce_to_field(i: T) -> Result<Term, String> {
     match &i.ty {
         Ty::Uint(_) => Ok(to_dflt_f(i.term)),
         Ty::Field => Ok(i.term),
-        _ => Err(format!("Cannot coerce {} to a field element", &i)),
+        _ => Err(format!("Cannot coerce {} to a field element", i)),
     }
 }
 
@@ -931,7 +931,7 @@ pub fn array_select(array: T, idx: T) -> Result<T, String> {
             let iterm = coerce_to_field(idx).unwrap();
             Ok(T::new(Ty::Field, term![Op::Select; array.term, iterm]))
         }
-        _ => Err(format!("Cannot index {} using {}", &array.ty, &idx.ty)),
+        _ => Err(format!("Cannot index {} using {}", array.ty, idx.ty)),
     }
 }
 
@@ -959,7 +959,7 @@ pub fn array_store(array: T, idx: T, val: T) -> Result<T, String> {
             term![Op::Store; array.term, iterm, val.term],
         ))
     } else {
-        Err(format!("Cannot index {} using {}", &array.ty, &idx.ty))
+        Err(format!("Cannot index {} using {}", array.ty, idx.ty))
     }
 }
 
@@ -1120,7 +1120,7 @@ pub fn bit_array_le(a: T, b: T, n: usize) -> Result<T, String> {
                 Ok(())
             }
         }
-        _ => Err(format!("Cannot do bit-array-le on ({}, {})", &a.ty, &b.ty)),
+        _ => Err(format!("Cannot do bit-array-le on ({}, {})", a.ty, b.ty)),
     }?;
 
     let at = bv_from_bits(a.term, n);

--- a/src/front/zsharp/zvisit/eqtype.rs
+++ b/src/front/zsharp/zvisit/eqtype.rs
@@ -55,7 +55,7 @@ fn eq_array_type<'ast>(
         (Struct(sty), Struct(sty2)) => eq_struct_type(sty, sty2, zgen),
         _ => Err(ZVisitorError(format!(
             "array type mismatch: \n\texpected elms of type {:?}, \n\tfound {:?}",
-            &ty.ty, &ty2.ty,
+            ty.ty, ty2.ty,
         ))),
     }
 }
@@ -71,7 +71,7 @@ fn eq_struct_type<'ast>(
         // neither ty nor ty2 is a type alias, so they are really different
         Err(ZVisitorError(format!(
             "struct type mismatch: \n\texpected {:?}, \n\tfound {:?}",
-            &ty.id.value, &ty2.id.value,
+            ty.id.value, ty2.id.value,
         )))
     } else {
         eq_type(&canon_type(ty, zgen)?, &canon_type(ty2, zgen)?, zgen)
@@ -97,7 +97,7 @@ fn canon_type<'ast>(ty: &ast::StructType<'ast>, zgen: &ZGen<'ast>) -> ZResult<as
         .ok_or_else(|| {
             ZVisitorError(format!(
                 "eqtype: unknown struct or type alias {}",
-                &ty.id.value
+                ty.id.value
             ))
         })
 }

--- a/src/front/zsharp/zvisit/zconstlitrw.rs
+++ b/src/front/zsharp/zvisit/zconstlitrw.rs
@@ -168,7 +168,7 @@ impl<'ast> ZVisitorMut<'ast> for ZConstLiteralRewriter {
         let ty_map = if let Some(t) = to_ty.as_ref() {
             if let Ty::Struct(name, ty_map) = t {
                 if name != &ise.ty.value {
-                    Err(format!("ZConstLiteralRewriter: got struct {}, expected {} visiting inline struct expression", &ise.ty.value, name))
+                    Err(format!("ZConstLiteralRewriter: got struct {}, expected {} visiting inline struct expression", ise.ty.value, name))
                 } else {
                     Ok(Some(ty_map.clone()))
                 }
@@ -190,7 +190,7 @@ impl<'ast> ZVisitorMut<'ast> for ZConstLiteralRewriter {
                     .remove(&m.id.value)
                     .ok_or_else(|| ZVisitorError(format!(
                         "ZConstLiteralRewriter: no member {} in struct {}, or duplicate member in inline expression",
-                        &m.id.value,
+                        m.id.value,
                         str_name,
                     )))
                     .and_then(|ty| {
@@ -202,7 +202,7 @@ impl<'ast> ZVisitorMut<'ast> for ZConstLiteralRewriter {
             if !ty_map.is_empty() {
                 return Err(format!(
                     "ZConstLiteralRewriter: inline expression for struct {} has extra fields: {:?}",
-                    &ise.ty.value,
+                    ise.ty.value,
                     ty_map.keys().collect::<Vec<_>>(),
                 )
                 .into());

--- a/src/front/zsharp/zvisit/zgenericinf.rs
+++ b/src/front/zsharp/zvisit/zgenericinf.rs
@@ -115,7 +115,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
                     Ty::Uint(32) => Ok(v.term),
                     ty => Err(format!(
                         "ZGenericInf: ConstantGenericValue for {} had type {}, expected u32",
-                        &id.value, ty
+                        id.value, ty
                     )),
                 }?;
                 self.add_constraint(var, val);
@@ -135,7 +135,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
             (Some(rty), Some(ret)) => self.fdef_gen_ty(rty, ret),
             (Some(rty), None) if rty != Ty::Bool => Err(format!(
                 "Function {} expected implicit Bool ret, but got {}",
-                &self.fdef.id.value, rty
+                self.fdef.id.value, rty
             )),
             (Some(_), None) => Ok(()),
             (None, _) => Ok(()),
@@ -155,7 +155,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
         {
             assert!(self.gens.len() == res.len());
             assert!(self.gens.iter().all(|g| res.contains_key(&g.value)));
-            debug!("done (cached result for {})", &self.sfx);
+            debug!("done (cached result for {})", self.sfx);
             return Ok(res);
         }
         let g_names = self
@@ -285,7 +285,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
         let (stdef, stpath) = self
             .zgen
             .get_struct_or_type(&def_ty.id.value)
-            .ok_or_else(|| format!("ZGenericInf: no struct struct or type {}", &def_ty.id.value))?;
+            .ok_or_else(|| format!("ZGenericInf: no struct struct or type {}", def_ty.id.value))?;
         let generics = match &stdef {
             Ok(strdef) => &strdef.generics[..],
             Err(tydef) => &tydef.generics[..],
@@ -296,7 +296,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
             return if def_ty.explicit_generics.is_some() {
                 Err(format!(
                     "Unifying generics: got explicit generics for non-generic struct type {}:\n{}",
-                    &def_ty.id.value,
+                    def_ty.id.value,
                     span_to_string(&def_ty.span),
                 ))
             } else {
@@ -314,8 +314,8 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
         {
             return Err(format!(
                 "Cannot infer generic values for struct {} arg to function {}\nGeneric structs in fn defns must have explicit generics (in terms of fn generic vars)",
-                &def_ty.id.value,
-                &self.fdef.id.value,
+                def_ty.id.value,
+                self.fdef.id.value,
             ));
         }
 
@@ -358,7 +358,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
                     }
                     Ty::Struct(aty_n, _) => Err(format!(
                         "Type mismatch: got struct {aty_n}, decl was struct {}",
-                        &def_ty.id.value
+                        def_ty.id.value
                     )),
                     arg_ty => Err(format!(
                         "Type mismatch unifying generics: got {arg_ty}, decl was Struct",
@@ -370,14 +370,14 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
                     } else {
                         return Err(format!(
                             "ZGenericInf: missing member {} in struct {} value",
-                            &id.value, &def_ty.id.value,
+                            id.value, def_ty.id.value,
                         ));
                     }
                 }
                 if !aty_map.is_empty() {
                     return Err(format!(
                         "ZGenericInf: struct {} value had extra members: {:?}",
-                        &def_ty.id.value,
+                        def_ty.id.value,
                         aty_map.keys().collect::<Vec<_>>(),
                     ));
                 }

--- a/src/front/zsharp/zvisit/zstmtwalker/mod.rs
+++ b/src/front/zsharp/zvisit/zstmtwalker/mod.rs
@@ -98,7 +98,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         if call.arguments.expressions.len() != fdef.parameters.len() {
             return Err(format!(
                 "ZStatementWalker: wrong number of arguments to fn {}:\n{}",
-                &fdef.id.value,
+                fdef.id.value,
                 span_to_string(&call.span),
             )
             .into());
@@ -106,7 +106,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         if fdef.generics.is_empty() && call.explicit_generics.is_some() {
             return Err(format!(
                 "ZStatementWalker: got explicit generics for non-generic fn call {}:\n{}",
-                &fdef.id.value,
+                fdef.id.value,
                 span_to_string(&call.span),
             )
             .into());
@@ -119,7 +119,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         {
             return Err(format!(
                 "ZStatementWalker: wrong number of generic args to fn {}:\n{}",
-                &fdef.id.value,
+                fdef.id.value,
                 span_to_string(&call.span),
             )
             .into());
@@ -162,13 +162,13 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                     // XXX(unimpl) fn without return type not supported
                     Err(ZVisitorError(format!(
                         "ZStatementWalker: fn {} has no return type",
-                        &id.value,
+                        id.value,
                     )))
                 } else if fdef.returns.len() > 1 {
                     // XXX(unimpl) multiple return types not implemented
                     Err(ZVisitorError(format!(
                         "ZStatementWalker: fn {} has multiple returns",
-                        &id.value,
+                        id.value,
                     )))
                 } else {
                     let rty = if alen == 1 { rty } else { None };
@@ -204,7 +204,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         } else {
             return Err(ZVisitorError(format!(
                 "ZStatementWalker: array initializer expression wanted type {:?}:\n{}",
-                &ty,
+                ty,
                 span_to_string(&ai.span),
             )));
         };
@@ -234,7 +234,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         } else {
             return Err(ZVisitorError(format!(
                 "ZStatementWalker: inline struct wanted type {:?}:\n{}",
-                &ty,
+                ty,
                 span_to_string(&is.span),
             )));
         };
@@ -254,7 +254,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                 .ok_or_else(|| {
                     ZVisitorError(format!(
                         "ZStatementWalker: struct {} has no member {}, or duplicate member in expression",
-                        &st.id.value, &ism.id.value,
+                        st.id.value, ism.id.value,
                     ))
                 })
                 .and_then(|sm_ty| self.unify_expression(sm_ty, &mut ism.expression))
@@ -264,7 +264,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         if !sm_types.is_empty() {
             Err(ZVisitorError(format!(
                 "ZStatementWalker: struct {} inline decl missing members {:?}\n",
-                &st.id.value,
+                st.id.value,
                 sm_types.keys().collect::<Vec<_>>()
             )))
         } else {
@@ -283,7 +283,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         } else {
             return Err(ZVisitorError(format!(
                 "ZStatementWalker: inline array wanted type {:?}:\n{}",
-                &ty,
+                ty,
                 span_to_string(&ia.span),
             )));
         };
@@ -383,8 +383,8 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                                 .map_err(|e|
                                 ZVisitorError(format!(
                                     "ZStatementWalker: got differing types {:?}, {:?} for lhs, rhs of expr:\n{}\n{}",
-                                    &lty,
-                                    &rty,
+                                    lty,
+                                    rty,
                                     e.0,
                                     span_to_string(&be.span),
                                 )))
@@ -489,7 +489,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                 } else {
                     Err(ZVisitorError(format!(
                         "ZStatementWalker: expected {:?}, found BooleanLiteral:\n{}",
-                        &bt,
+                        bt,
                         span_to_string(le.span()),
                     )))
                 }
@@ -503,7 +503,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                     HNE::U64(_) if matches!(&bt, U64(_)) => Ok(()),
                     _ => Err(ZVisitorError(format!(
                         "ZStatementWalker: HexLiteral seemed to want type {:?}:\n{}",
-                        &bt,
+                        bt,
                         span_to_string(&hle.span),
                     ))),
                 }
@@ -520,7 +520,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                         (DS::Integer(_), Integer(_)) => Ok(()),
                         _ => Err(ZVisitorError(format!(
                             "ZStatementWalker: DecimalLiteral wanted {:?} found {:?}:\n{}",
-                            &bt,
+                            bt,
                             ds,
                             span_to_string(&dle.span),
                         ))),
@@ -597,7 +597,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                             .ok_or_else(|| {
                                 ZVisitorError(format!(
                                     "ZStatementWalker: struct {} has no member {}",
-                                    &sty.id.value, &macc.id.value,
+                                    sty.id.value, macc.id.value,
                                 ))
                             })
                             .map(|f| f.ty.clone())?
@@ -674,7 +674,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
             self.lookup_var(&id.value).ok_or_else(|| {
                 ZVisitorError(format!(
                     "ZStatementWalker: identifier {} undefined",
-                    &id.value
+                    id.value
                 ))
             })
         }
@@ -849,7 +849,7 @@ impl<'ast> ZVisitorMut<'ast> for ZStatementWalker<'ast, '_> {
         if !self.var_defined(&asgn.id.value) {
             Err(ZVisitorError(format!(
                 "ZStatementWalker: assignment to undeclared variable {}",
-                &asgn.id.value
+                asgn.id.value
             )))
         } else {
             walk_assignee(self, asgn)

--- a/src/front/zsharpcurly/mod.rs
+++ b/src/front/zsharpcurly/mod.rs
@@ -177,6 +177,11 @@ enum ZVis {
     Private(u8),
 }
 
+enum ArrayParamMetadata {
+    Committed,
+    Transcript,
+}
+
 impl<'ast> ZGen<'ast> {
     fn new(
         asts: HashMap<PathBuf, ast::File<'ast>>,
@@ -1067,10 +1072,22 @@ impl<'ast> ZGen<'ast> {
         for p in f.parameters.iter() {
             let ty = self.type_(&p.ty);
             debug!("Entry param: {}: {}", p.id.value, ty);
-            // XXX(unimpl) array metadata
+            let md = self.interpret_array_md(&p.array_metadata);
             let vis = self.interpret_visibility(&p.visibility);
             let r = self.circ_declare_input(p.id.value.clone(), &ty, vis, None, false);
-            self.unwrap(r, &p.span);
+            let input = self.unwrap(r, &p.span);
+            match md {
+                Some(ArrayParamMetadata::Transcript) => {
+                    self.mark_array_as_transcript(&p.id.value, input);
+                }
+                Some(ArrayParamMetadata::Committed) => {
+                    self.err(
+                        "committed (persistent) arrays are not yet supported by the zsharp-curly frontend",
+                        &p.span,
+                    );
+                }
+                None => {}
+            }
         }
         for s in &f.statements {
             self.unwrap(self.stmt_impl_::<false>(s), s.span());
@@ -1163,6 +1180,33 @@ impl<'ast> ZGen<'ast> {
             debug!("Assertion: {}", to_assert);
             self.circ.borrow_mut().assert(to_assert);
         }
+    }
+
+    fn interpret_array_md(
+        &self,
+        md: &Option<ast::ArrayParamMetadata<'ast>>,
+    ) -> Option<ArrayParamMetadata> {
+        match md {
+            Some(ast::ArrayParamMetadata::Committed(_)) => Some(ArrayParamMetadata::Committed),
+            Some(ast::ArrayParamMetadata::Transcript(_)) => Some(ArrayParamMetadata::Transcript),
+            None => None,
+        }
+    }
+
+    fn mark_array_as_transcript(&self, name: &str, array: T) {
+        info!(
+            "Transcript array {} of type {} in {:?}",
+            name,
+            array.ty,
+            self.file_stack.borrow().last().unwrap()
+        );
+        self.circ
+            .borrow()
+            .cir_ctx()
+            .cs
+            .borrow_mut()
+            .ram_arrays
+            .insert(array.term);
     }
 
     fn interpret_visibility(&self, visibility: &Option<ast::Visibility>) -> ZVis {

--- a/src/front/zsharpcurly/mod.rs
+++ b/src/front/zsharpcurly/mod.rs
@@ -57,7 +57,7 @@ fn const_bool_simple(t: T) -> Option<bool> {
 fn const_val_simple(a: T) -> Result<T, String> {
     match const_value_simple(&a.term) {
         Some(v) => Ok(T::new(a.ty, leaf_term(Op::new_const(v)))),
-        _ => Err(format!("{} is not a constant value", &a)),
+        _ => Err(format!("{} is not a constant value", a)),
     }
 }
 
@@ -848,9 +848,9 @@ impl<'ast> ZGen<'ast> {
         let f = self
             .functions
             .get(&f_path)
-            .ok_or_else(|| format!("No file '{:?}' attempting fn call", &f_path))?
+            .ok_or_else(|| format!("No file '{:?}' attempting fn call", f_path))?
             .get(&f_name)
-            .ok_or_else(|| format!("No function '{}' attempting fn call", &f_name))?;
+            .ok_or_else(|| format!("No function '{}' attempting fn call", f_name))?;
         let arg_tys = args.iter().map(|arg| arg.type_().clone());
         let generics = ZGenericInf::<IS_CNST>::new(self, f, &f_path, &f_name)
             .unify_generic(egv, exp_ty, arg_tys)?;
@@ -887,7 +887,7 @@ impl<'ast> ZGen<'ast> {
         };
         let dur = (time::Instant::now() - before).as_millis();
         if dur > 50 {
-            info!("{} ms to process {} {:?}", dur, &f_name, &f_path);
+            info!("{} ms to process {} {:?}", dur, f_name, f_path);
         }
         ret
     }
@@ -909,7 +909,7 @@ impl<'ast> ZGen<'ast> {
                     generics.remove(&gid.value).ok_or_else(|| {
                         format!(
                             "Failed to find generic argument {} for builtin call {}",
-                            &gid.value, &f_name,
+                            gid.value, f_name,
                         )
                     })
                 })
@@ -919,7 +919,7 @@ impl<'ast> ZGen<'ast> {
             if f.generics.len() != generics.len() {
                 return Err(format!(
                     "Wrong number of generic params calling {} (got {}, expected {})",
-                    &f.id.value,
+                    f.id.value,
                     generics.len(),
                     f.generics.len()
                 ));
@@ -927,7 +927,7 @@ impl<'ast> ZGen<'ast> {
             if f.parameters.len() != args.len() {
                 return Err(format!(
                     "Wrong nimber of arguments calling {} (got {}, expected {})",
-                    &f.id.value,
+                    f.id.value,
                     args.len(),
                     f.parameters.len()
                 ));
@@ -1044,7 +1044,7 @@ impl<'ast> ZGen<'ast> {
         } else {
             panic!(
                 "No function '{:?}//{}' attempting const_entry_fn",
-                &f_file, &f_name
+                f_file, f_name
             )
         }
     }
@@ -1056,9 +1056,9 @@ impl<'ast> ZGen<'ast> {
         let f = self
             .functions
             .get(&f_file)
-            .unwrap_or_else(|| panic!("No file '{:?}'", &f_file))
+            .unwrap_or_else(|| panic!("No file '{:?}'", f_file))
             .get(&f_name)
-            .unwrap_or_else(|| panic!("No function '{}'", &f_name))
+            .unwrap_or_else(|| panic!("No function '{}'", f_name))
             .clone();
         // XXX(unimpl) tuple returns not supported
         if !f.generics.is_empty() {
@@ -1289,7 +1289,7 @@ impl<'ast> ZGen<'ast> {
             None if IS_CNST => self.cvar_lookup(&i.value).ok_or_else(|| {
                 format!(
                     "Undefined const identifier {} in {}",
-                    &i.value,
+                    i.value,
                     self.cur_path().to_string_lossy()
                 )
             }),
@@ -1298,7 +1298,7 @@ impl<'ast> ZGen<'ast> {
                 .map_err(|e| format!("{e}"))?
             {
                 Val::Term(t) => Ok(t),
-                _ => Err(format!("Non-Term identifier {}", &i.value)),
+                _ => Err(format!("Non-Term identifier {}", i.value)),
             },
         }
     }
@@ -1435,13 +1435,7 @@ impl<'ast> ZGen<'ast> {
                         ast::Expression::Identifier(id) => self.deref_import(&id.value),
                         _ => panic!("Expected identifier in postfix expression base"),
                     };
-                    let exp_ty = self.lhs_ty_take().and_then(|ty| {
-                        if p.accesses.len() > 1 {
-                            None
-                        } else {
-                            Some(ty)
-                        }
-                    });
+                    let exp_ty = self.lhs_ty_take().filter(|_ty| p.accesses.len() <= 1);
                     let args = c
                         .arguments
                         .expressions
@@ -1948,7 +1942,7 @@ impl<'ast> ZGen<'ast> {
             self.err(
                 format!(
                     "Constant {} clashes with import of same name",
-                    &c.id.identifier.value
+                    c.id.identifier.value
                 ),
                 &c.span,
             );
@@ -1989,7 +1983,7 @@ impl<'ast> ZGen<'ast> {
             .is_some()
         {
             self.err(
-                format!("Constant {} redefined", &c.id.identifier.value),
+                format!("Constant {} redefined", c.id.identifier.value),
                 &c.span,
             );
         }
@@ -2031,7 +2025,7 @@ impl<'ast> ZGen<'ast> {
                 let (def, path) = self.get_struct_or_type(&s.id.value).ok_or_else(|| {
                     format!(
                         "No such struct {} (did you bring it into scope?)",
-                        &s.id.value
+                        s.id.value
                     )
                 })?;
                 let generics = match def {
@@ -2048,7 +2042,7 @@ impl<'ast> ZGen<'ast> {
                 if generics.len() != g_len {
                     return Err(format!(
                         "Struct {} is not monomorphized or wrong number of generic parameters",
-                        &s.id.value
+                        s.id.value
                     ));
                 }
                 self.file_stack_push(path);
@@ -2262,7 +2256,7 @@ impl<'ast> ZGen<'ast> {
                             .is_some()
                         {
                             self.err(
-                                format!("Struct {} defined over existing name", &s.id.value),
+                                format!("Struct {} defined over existing name", s.id.value),
                                 &s.span,
                             );
                         }
@@ -2287,7 +2281,7 @@ impl<'ast> ZGen<'ast> {
                             .is_some()
                         {
                             self.err(
-                                format!("Type {} defined over existing name", &t.id.value),
+                                format!("Type {} defined over existing name", t.id.value),
                                 &t.span,
                             );
                         }
@@ -2334,7 +2328,7 @@ impl<'ast> ZGen<'ast> {
                             .insert(f.id.value.clone(), f_ast)
                             .is_some()
                         {
-                            self.err(format!("Function {} redefined", &f.id.value), &f.span);
+                            self.err(format!("Function {} redefined", f.id.value), &f.span);
                         }
                     }
                     ast::SymbolDeclaration::Import(_) => (), // already handled in visit_imports

--- a/src/front/zsharpcurly/term.rs
+++ b/src/front/zsharpcurly/term.rs
@@ -767,7 +767,7 @@ pub fn const_fold(t: T) -> T {
 pub fn const_val(a: T) -> Result<T, String> {
     match const_value(&a.term) {
         Some(v) => Ok(T::new(a.ty, const_(v))),
-        _ => Err(format!("{} is not a constant value", &a)),
+        _ => Err(format!("{} is not a constant value", a)),
     }
 }
 
@@ -938,7 +938,7 @@ fn coerce_to_field(i: T) -> Result<Term, String> {
     match &i.ty {
         Ty::Uint(_) => Ok(to_dflt_f(i.term)),
         Ty::Field => Ok(i.term),
-        _ => Err(format!("Cannot coerce {} to a field element", &i)),
+        _ => Err(format!("Cannot coerce {} to a field element", i)),
     }
 }
 
@@ -952,7 +952,7 @@ pub fn array_select(array: T, idx: T) -> Result<T, String> {
             let iterm = coerce_to_field(idx).unwrap();
             Ok(T::new(Ty::Field, term![Op::Select; array.term, iterm]))
         }
-        _ => Err(format!("Cannot index {} using {}", &array.ty, &idx.ty)),
+        _ => Err(format!("Cannot index {} using {}", array.ty, idx.ty)),
     }
 }
 
@@ -969,7 +969,7 @@ pub fn array_store(array: T, idx: T, val: T) -> Result<T, String> {
             term![Op::Store; array.term, iterm, val.term],
         ))
     } else {
-        Err(format!("Cannot index {} using {}", &array.ty, &idx.ty))
+        Err(format!("Cannot index {} using {}", array.ty, idx.ty))
     }
 }
 
@@ -1137,7 +1137,7 @@ pub fn bit_array_le(a: T, b: T, n: usize) -> Result<T, String> {
                 Ok(())
             }
         }
-        _ => Err(format!("Cannot do bit-array-le on ({}, {})", &a.ty, &b.ty)),
+        _ => Err(format!("Cannot do bit-array-le on ({}, {})", a.ty, b.ty)),
     }?;
 
     let at = bv_from_bits(a.term, n);

--- a/src/front/zsharpcurly/zvisit/eqtype.rs
+++ b/src/front/zsharpcurly/zvisit/eqtype.rs
@@ -74,7 +74,7 @@ fn eq_array_type<'ast>(
         (Struct(sty), Struct(sty2)) => eq_struct_type(sty, sty2, zgen),
         _ => Err(ZVisitorError(format!(
             "array type mismatch: \n\texpected elms of type {:?}, \n\tfound {:?}",
-            &ty.ty, &ty2.ty,
+            ty.ty, ty2.ty,
         ))),
     }
 }
@@ -90,7 +90,7 @@ fn eq_struct_type<'ast>(
         // neither ty nor ty2 is a type alias, so they are really different
         Err(ZVisitorError(format!(
             "struct type mismatch: \n\texpected {:?}, \n\tfound {:?}",
-            &ty.id.value, &ty2.id.value,
+            ty.id.value, ty2.id.value,
         )))
     } else {
         eq_type(&canon_type(ty, zgen)?, &canon_type(ty2, zgen)?, zgen)
@@ -136,7 +136,7 @@ fn canon_type<'ast>(ty: &ast::StructType<'ast>, zgen: &ZGen<'ast>) -> ZResult<as
         .ok_or_else(|| {
             ZVisitorError(format!(
                 "eqtype: unknown struct or type alias {}",
-                &ty.id.value
+                ty.id.value
             ))
         })
 }

--- a/src/front/zsharpcurly/zvisit/zconstlitrw.rs
+++ b/src/front/zsharpcurly/zvisit/zconstlitrw.rs
@@ -181,7 +181,7 @@ impl<'ast> ZVisitorMut<'ast> for ZConstLiteralRewriter {
         let ty_map = if let Some(t) = to_ty.as_ref() {
             if let Ty::Struct(name, ty_map) = t {
                 if name != &ise.ty.value {
-                    Err(format!("ZConstLiteralRewriter: got struct {}, expected {} visiting inline struct expression", &ise.ty.value, name))
+                    Err(format!("ZConstLiteralRewriter: got struct {}, expected {} visiting inline struct expression", ise.ty.value, name))
                 } else {
                     Ok(Some(ty_map.clone()))
                 }
@@ -203,7 +203,7 @@ impl<'ast> ZVisitorMut<'ast> for ZConstLiteralRewriter {
                     .remove(&m.id.value)
                     .ok_or_else(|| ZVisitorError(format!(
                         "ZConstLiteralRewriter: no member {} in struct {}, or duplicate member in inline expression",
-                        &m.id.value,
+                        m.id.value,
                         str_name,
                     )))
                     .and_then(|ty| {
@@ -215,7 +215,7 @@ impl<'ast> ZVisitorMut<'ast> for ZConstLiteralRewriter {
             if !ty_map.is_empty() {
                 return Err(format!(
                     "ZConstLiteralRewriter: inline expression for struct {} has extra fields: {:?}",
-                    &ise.ty.value,
+                    ise.ty.value,
                     ty_map.keys().collect::<Vec<_>>(),
                 )
                 .into());

--- a/src/front/zsharpcurly/zvisit/zgenericinf.rs
+++ b/src/front/zsharpcurly/zvisit/zgenericinf.rs
@@ -115,7 +115,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
                     Ty::Uint(32) => Ok(v.term),
                     ty => Err(format!(
                         "ZGenericInf: ConstantGenericValue for {} had type {}, expected u32",
-                        &id.value, ty
+                        id.value, ty
                     )),
                 }?;
                 self.add_constraint(var, val);
@@ -135,7 +135,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
             (Some(rty), Some(ret)) => self.fdef_gen_ty(rty, ret),
             (Some(rty), None) if rty != Ty::Bool => Err(format!(
                 "Function {} expected implicit Bool ret, but got {}",
-                &self.fdef.id.value, rty
+                self.fdef.id.value, rty
             )),
             (Some(_), None) => Ok(()),
             (None, _) => Ok(()),
@@ -155,7 +155,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
         {
             assert!(self.gens.len() == res.len());
             assert!(self.gens.iter().all(|g| res.contains_key(&g.value)));
-            debug!("done (cached result for {})", &self.sfx);
+            debug!("done (cached result for {})", self.sfx);
             return Ok(res);
         }
         let g_names = self
@@ -287,7 +287,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
         let (stdef, stpath) = self
             .zgen
             .get_struct_or_type(&def_ty.id.value)
-            .ok_or_else(|| format!("ZGenericInf: no struct struct or type {}", &def_ty.id.value))?;
+            .ok_or_else(|| format!("ZGenericInf: no struct struct or type {}", def_ty.id.value))?;
         let generics = match &stdef {
             Ok(strdef) => &strdef.generics[..],
             Err(tydef) => &tydef.generics[..],
@@ -298,7 +298,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
             return if def_ty.explicit_generics.is_some() {
                 Err(format!(
                     "Unifying generics: got explicit generics for non-generic struct type {}:\n{}",
-                    &def_ty.id.value,
+                    def_ty.id.value,
                     span_to_string(&def_ty.span),
                 ))
             } else {
@@ -316,8 +316,8 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
         {
             return Err(format!(
                 "Cannot infer generic values for struct {} arg to function {}\nGeneric structs in fn defns must have explicit generics (in terms of fn generic vars)",
-                &def_ty.id.value,
-                &self.fdef.id.value,
+                def_ty.id.value,
+                self.fdef.id.value,
             ));
         }
 
@@ -360,7 +360,7 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
                     }
                     Ty::Struct(aty_n, _) => Err(format!(
                         "Type mismatch: got struct {aty_n}, decl was struct {}",
-                        &def_ty.id.value
+                        def_ty.id.value
                     )),
                     arg_ty => Err(format!(
                         "Type mismatch unifying generics: got {arg_ty}, decl was Struct",
@@ -372,14 +372,14 @@ impl<'ast, 'gen, const IS_CNST: bool> ZGenericInf<'ast, 'gen, IS_CNST> {
                     } else {
                         return Err(format!(
                             "ZGenericInf: missing member {} in struct {} value",
-                            &id.identifier.value, &def_ty.id.value,
+                            id.identifier.value, def_ty.id.value,
                         ));
                     }
                 }
                 if !aty_map.is_empty() {
                     return Err(format!(
                         "ZGenericInf: struct {} value had extra members: {:?}",
-                        &def_ty.id.value,
+                        def_ty.id.value,
                         aty_map.keys().collect::<Vec<_>>(),
                     ));
                 }

--- a/src/front/zsharpcurly/zvisit/zstmtwalker/mod.rs
+++ b/src/front/zsharpcurly/zvisit/zstmtwalker/mod.rs
@@ -100,7 +100,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         if call.arguments.expressions.len() != fdef.parameters.len() {
             return Err(format!(
                 "ZStatementWalker: wrong number of arguments to fn {}:\n{}",
-                &fdef.id.value,
+                fdef.id.value,
                 span_to_string(&call.span),
             )
             .into());
@@ -108,7 +108,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         if fdef.generics.is_empty() && call.explicit_generics.is_some() {
             return Err(format!(
                 "ZStatementWalker: got explicit generics for non-generic fn call {}:\n{}",
-                &fdef.id.value,
+                fdef.id.value,
                 span_to_string(&call.span),
             )
             .into());
@@ -121,7 +121,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         {
             return Err(format!(
                 "ZStatementWalker: wrong number of generic args to fn {}:\n{}",
-                &fdef.id.value,
+                fdef.id.value,
                 span_to_string(&call.span),
             )
             .into());
@@ -171,7 +171,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                         // Function without a return type is not supported
                         Err(ZVisitorError(format!(
                             "ZStatementWalker: fn {} has no return type",
-                            &id.value,
+                            id.value,
                         )))
                     }
                     Some(_) => {
@@ -210,7 +210,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         } else {
             return Err(ZVisitorError(format!(
                 "ZStatementWalker: array initializer expression wanted type {:?}:\n{}",
-                &ty,
+                ty,
                 span_to_string(&ai.span),
             )));
         };
@@ -240,7 +240,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         } else {
             return Err(ZVisitorError(format!(
                 "ZStatementWalker: inline struct wanted type {:?}:\n{}",
-                &ty,
+                ty,
                 span_to_string(&is.span),
             )));
         };
@@ -260,7 +260,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                 .ok_or_else(|| {
                     ZVisitorError(format!(
                         "ZStatementWalker: struct {} has no member {}, or duplicate member in expression",
-                        &st.id.value, &ism.id.value,
+                        st.id.value, ism.id.value,
                     ))
                 })
                 .and_then(|sm_ty| self.unify_expression(sm_ty, &mut ism.expression))
@@ -270,7 +270,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         if !sm_types.is_empty() {
             Err(ZVisitorError(format!(
                 "ZStatementWalker: struct {} inline decl missing members {:?}\n",
-                &st.id.value,
+                st.id.value,
                 sm_types.keys().collect::<Vec<_>>()
             )))
         } else {
@@ -289,7 +289,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         } else {
             return Err(ZVisitorError(format!(
                 "ZStatementWalker: inline array wanted type {:?}:\n{}",
-                &ty,
+                ty,
                 span_to_string(&ia.span),
             )));
         };
@@ -321,7 +321,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
         } else {
             return Err(ZVisitorError(format!(
                 "ZStatementWalker: inline tuple wanted type {:?}:\n{}",
-                &ty,
+                ty,
                 span_to_string(&it.span),
             )));
         };
@@ -447,8 +447,8 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                                 .map_err(|e|
                                 ZVisitorError(format!(
                                     "ZStatementWalker: got differing types {:?}, {:?} for lhs, rhs of expr:\n{}\n{}",
-                                    &lty,
-                                    &rty,
+                                    lty,
+                                    rty,
                                     e.0,
                                     span_to_string(&be.span),
                                 )))
@@ -546,7 +546,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                 } else {
                     Err(ZVisitorError(format!(
                         "ZStatementWalker: expected {:?}, found BooleanLiteral:\n{}",
-                        &bt,
+                        bt,
                         span_to_string(le.span()),
                     )))
                 }
@@ -560,7 +560,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                     HNE::U64(_) if matches!(&bt, U64(_)) => Ok(()),
                     _ => Err(ZVisitorError(format!(
                         "ZStatementWalker: HexLiteral seemed to want type {:?}:\n{}",
-                        &bt,
+                        bt,
                         span_to_string(&hle.span),
                     ))),
                 }
@@ -576,7 +576,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                         (DS::U64(_), U64(_)) => Ok(()),
                         _ => Err(ZVisitorError(format!(
                             "ZStatementWalker: DecimalLiteral wanted {:?} found {:?}:\n{}",
-                            &bt,
+                            bt,
                             ds,
                             span_to_string(&dle.span),
                         ))),
@@ -659,7 +659,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
                                 .ok_or_else(|| {
                                     ZVisitorError(format!(
                                         "ZStatementWalker: struct {} has no member {}",
-                                        &sty.id.value,
+                                        sty.id.value,
                                         if let ast::IdentifierOrDecimal::Identifier(id) = &macc.inner {
                                             &id.value
                                         } else {
@@ -762,7 +762,7 @@ impl<'ast, 'ret> ZStatementWalker<'ast, 'ret> {
             self.lookup_var(&id.value).ok_or_else(|| {
                 ZVisitorError(format!(
                     "ZStatementWalker: identifier {} undefined",
-                    &id.value
+                    id.value
                 ))
             })
         }
@@ -905,7 +905,7 @@ impl<'ast> ZVisitorMut<'ast> for ZStatementWalker<'ast, '_> {
         if !self.var_defined(&asgn.id.value) {
             Err(ZVisitorError(format!(
                 "ZStatementWalker: assignment to undeclared variable {}",
-                &asgn.id.value
+                asgn.id.value
             )))
         } else {
             walk_assignee(self, asgn)

--- a/src/ir/opt/mod.rs
+++ b/src/ir/opt/mod.rs
@@ -80,7 +80,7 @@ pub fn opt<I: IntoIterator<Item = Opt>>(mut cs: Computations, optimizations: I) 
             continue;
         }
 
-        for (_, c) in cs.comps.iter_mut() {
+        for c in cs.comps.values_mut() {
             match i.clone() {
                 Opt::ParseCondStores => {
                     cstore::parse(c);
@@ -188,7 +188,7 @@ pub fn opt<I: IntoIterator<Item = Opt>>(mut cs: Computations, optimizations: I) 
         garbage_collect();
     }
 
-    for (_, c) in cs.comps.iter() {
+    for c in cs.comps.values() {
         info!("{:?}", c.outputs);
     }
     cs

--- a/src/ir/term/bv.rs
+++ b/src/ir/term/bv.rs
@@ -257,14 +257,14 @@ impl Display for BitVector {
             write!(
                 f,
                 "#x{:0>width$}",
-                &format!("{:x}", self.uint).as_str(),
+                format!("{:x}", self.uint).as_str(),
                 width = self.width / 4
             )?;
         } else {
             write!(
                 f,
                 "#b{:0>width$}",
-                &format!("{:b}", self.uint).as_str(),
+                format!("{:b}", self.uint).as_str(),
                 width = self.width
             )?;
         }

--- a/src/ir/term/mod.rs
+++ b/src/ir/term/mod.rs
@@ -2131,7 +2131,7 @@ impl Computation {
     /// Assert `s` in the system.
     pub fn assert(&mut self, s: Term) {
         assert!(check(&s) == Sort::Bool);
-        debug!("Assert: {}", &s.op());
+        debug!("Assert: {}", s.op());
         self.outputs.push(s);
     }
 

--- a/src/ir/term/text/mod.rs
+++ b/src/ir/term/text/mod.rs
@@ -633,7 +633,7 @@ impl<'src> IrInterp<'src> {
             prefix,
             "Expected list head '{}', but found {}",
             prefix,
-            &tts[0]
+            tts[0]
         );
         &tts[1..]
     }

--- a/src/target/aby/assignment/ilp.rs
+++ b/src/target/aby/assignment/ilp.rs
@@ -103,7 +103,7 @@ fn build_ilp(c: &Computation, costs: &CostModel) -> SharingMap {
                         vars.push(v);
                     }
                 } else {
-                    panic!("No cost for op {}", &t.op())
+                    panic!("No cost for op {}", t.op())
                 }
             }
         }

--- a/src/target/aby/trans.rs
+++ b/src/target/aby/trans.rs
@@ -865,7 +865,7 @@ impl<'a> ToABY<'a> {
             fs::remove_file(&bytecode_output_path).unwrap_or_else(|_| {
                 panic!(
                     "Failed to remove bytecode output: {}",
-                    &bytecode_output_path
+                    bytecode_output_path
                 )
             });
 

--- a/src/target/aby/trans.rs
+++ b/src/target/aby/trans.rs
@@ -863,10 +863,7 @@ impl<'a> ToABY<'a> {
 
             // delete output bytecode files
             fs::remove_file(&bytecode_output_path).unwrap_or_else(|_| {
-                panic!(
-                    "Failed to remove bytecode output: {}",
-                    bytecode_output_path
-                )
+                panic!("Failed to remove bytecode output: {}", bytecode_output_path)
             });
 
             //reset for next function

--- a/third_party/ZoKratesCurly/zokrates_parser/src/zokrates.pest
+++ b/third_party/ZoKratesCurly/zokrates_parser/src/zokrates.pest
@@ -20,7 +20,11 @@ constant_generics_declaration = _{ "<" ~ constant_generics_list ~ ">" }
 constant_generics_list = _{ identifier ~ ("," ~ identifier)* }
 
 parameter_list = _{(parameter ~ ("," ~ parameter)*)?}
-parameter = { vis? ~ ty ~ _mut? ~ identifier }
+parameter = { array_param_metadata? ~ vis? ~ ty ~ _mut? ~ identifier }
+
+array_param_metadata = { apm_committed | apm_transcript }
+apm_committed = { "committed" }
+apm_transcript = { "transcript" }
 
 // basic types
 ty_field = {"field"}

--- a/third_party/ZoKratesCurly/zokrates_pest_ast/src/lib.rs
+++ b/third_party/ZoKratesCurly/zokrates_pest_ast/src/lib.rs
@@ -11,7 +11,8 @@ use zokrates_parser::Rule;
 extern crate lazy_static;
 
 pub use ast::{
-    Access, Arguments, ArrayAccess, ArrayInitializerExpression, ArrayType, AssemblyAssignment,
+    Access, Arguments, ArrayAccess, ArrayCommitted, ArrayInitializerExpression, ArrayParamMetadata,
+    ArrayTranscript, ArrayType, AssemblyAssignment,
     AssemblyConstraint, AssemblyStatement, AssemblyStatementInner, AssertionStatement,
     AssignConstrainOperator, AssignOperator, Assignee, AssigneeAccess, AssignmentOperator,
     BasicOrStructOrTupleType, BasicType, BinaryExpression, BinaryOperator,
@@ -343,10 +344,32 @@ mod ast {
     #[derive(Debug, FromPest, PartialEq, Clone)]
     #[pest_ast(rule(Rule::parameter))]
     pub struct Parameter<'ast> {
+        pub array_metadata: Option<ArrayParamMetadata<'ast>>,
         pub visibility: Option<Visibility>,
         pub ty: Type<'ast>,
         pub mutable: Option<Mutable>,
         pub id: IdentifierExpression<'ast>,
+        #[pest_ast(outer())]
+        pub span: Span<'ast>,
+    }
+
+    #[derive(Debug, FromPest, PartialEq, Clone)]
+    #[pest_ast(rule(Rule::array_param_metadata))]
+    pub enum ArrayParamMetadata<'ast> {
+        Committed(ArrayCommitted<'ast>),
+        Transcript(ArrayTranscript<'ast>),
+    }
+
+    #[derive(Debug, FromPest, PartialEq, Clone)]
+    #[pest_ast(rule(Rule::apm_committed))]
+    pub struct ArrayCommitted<'ast> {
+        #[pest_ast(outer())]
+        pub span: Span<'ast>,
+    }
+
+    #[derive(Debug, FromPest, PartialEq, Clone)]
+    #[pest_ast(rule(Rule::apm_transcript))]
+    pub struct ArrayTranscript<'ast> {
         #[pest_ast(outer())]
         pub span: Span<'ast>,
     }


### PR DESCRIPTION
NOTE: Claude Opus wrote this whole code change.

Add the syntax labels needed to mark arrays as RAM or ROM using the ram extension in CirC to ZoKrates Curly, the new version of ZoKrates. Actually pipe through the ROM marking. (I didn't implement the RAM one because I don't need that one right now.)